### PR TITLE
[POM] Add distribution management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,17 @@
     </dependencies>
   </dependencyManagement>
 
+  <distributionManagement>
+    <repository>
+      <id>aerius-nexus</id>
+      <url>https://nexus.aerius.nl/repository/maven-releases/</url>
+    </repository>
+    <snapshotRepository>
+      <id>aerius-nexus</id>
+      <url>https://nexus.aerius.nl/repository/maven-snapshots/</url>
+    </snapshotRepository>
+  </distributionManagement>
+
   <repositories>
     <repository>
       <id>aerius-nexus-public</id>


### PR DESCRIPTION
Another way would be to use the `aerius-root-pom`, which contains this, the license and some other stuff.