### PR TITLE
Support immutable POJOs by using their constructor (if any)

### DIFF
--- a/generate-parsers.sh
+++ b/generate-parsers.sh
@@ -5,7 +5,7 @@ set -e
 
 # Function to print usage
 print_usage() {
-    echo "Usage: $0 --project-dir <maven-project-dir> --root-class <root-class> --output-dir <output-dir> --parser-package <parser-package> [--custom-parser-dir <custom-parser-dir>]"
+    echo "Usage: $0 --project-dir <maven-project-dir> --root-class <root-class> --output-dir <output-dir> --parser-package <parser-package> [--custom-parser-dir <custom-parser-dir>] [--extra-source-root <dir>]..."
     echo ""
     echo "Arguments:"
     echo "  --project-dir        The directory containing the Maven project for which to generate parsers"
@@ -13,10 +13,14 @@ print_usage() {
     echo "  --output-dir         Directory where generated parsers will be written"
     echo "  --parser-package     Package name for the generated parsers"
     echo "  --custom-parser-dir  (Optional) Directory containing custom parser implementations"
+    echo "  --extra-source-root  (Optional) Extra source root directory (can be specified multiple times)"
     exit 1
 }
 
 echo "Debug: Script started"
+
+# Initialize array for extra source roots
+EXTRA_SOURCE_ROOTS=()
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -39,6 +43,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --custom-parser-dir)
             CUSTOM_PARSER_DIR="$2"
+            shift 2
+            ;;
+        --extra-source-root)
+            EXTRA_SOURCE_ROOTS+=("$2")
             shift 2
             ;;
         *)
@@ -149,6 +157,10 @@ GENERATOR_ARGS=(
 if [[ -n "$CUSTOM_PARSER_DIR" ]]; then
     GENERATOR_ARGS+=("--custom-parser-dir" "$CUSTOM_PARSER_DIR")
 fi
+
+for extra_root in "${EXTRA_SOURCE_ROOTS[@]}"; do
+    GENERATOR_ARGS+=("--extra-source-root" "$extra_root")
+done
 
 # --- Modified java command (ensure variables are passed, remove line continuations) ---
 echo "Running GWT Bean Parser Generator..."

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/Main.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/Main.java
@@ -33,6 +33,8 @@ public class Main {
 
       Optional Options:
       --custom-parser-dir, -c <dir> Directory containing custom parsers
+      --source-root, -s <dir>     Source root directory (can be specified multiple times).
+                                  If not specified, derived from classpath.
       --help, -h                 Show this help message
       """;
 
@@ -57,6 +59,15 @@ public class Main {
     System.out.println("  Parser package: " + options.parserPackage);
     System.out.println(
         "  Custom parser directory: " + (options.customParserDir != null ? options.customParserDir : "not specified"));
+
+    // Derive source roots from classpath if not explicitly specified
+    java.util.List<String> sourceRoots = options.sourceRoots;
+    if (sourceRoots.isEmpty()) {
+      sourceRoots = nl.aerius.codegen.util.FileUtils.deriveSourceRootsFromClasspath();
+      System.out.println("  Source roots (derived from classpath): " + sourceRoots);
+    } else {
+      System.out.println("  Source roots (explicitly specified): " + sourceRoots);
+    }
     System.out.println();
 
     try {
@@ -64,7 +75,7 @@ public class Main {
       final ClassFinder classFinder = new ClassFinder() {};
 
       ParserWriterUtils.initParsers(classFinder, logger);
-      ParserGenerator.generateParsers(options.rootClassName, options.outputDir, options.parserPackage, options.customParserDir, classFinder, logger);
+      ParserGenerator.generateParsers(options.rootClassName, options.outputDir, options.parserPackage, options.customParserDir, sourceRoots, classFinder, logger);
       System.out.println("\n✓ Parser generation completed successfully");
     } catch (final Exception e) {
       System.err.println("Error: " + e.getMessage());
@@ -114,6 +125,13 @@ public class Main {
           System.err.println("Missing value for --custom-parser-dir");
           return null;
         }
+      } else if ("--source-root".equals(arg) || "-s".equals(arg)) {
+        if (i + 1 < args.length) {
+          options.sourceRoots.add(args[++i]);
+        } else {
+          System.err.println("Missing value for --source-root");
+          return null;
+        }
       } else {
         System.err.println("Unknown argument: " + arg);
         printUsage();
@@ -139,5 +157,6 @@ public class Main {
     String outputDir;
     String parserPackage;
     String customParserDir = null;
+    java.util.List<String> sourceRoots = new java.util.ArrayList<>();
   }
 }

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/Main.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/Main.java
@@ -38,6 +38,8 @@ public class Main {
       --custom-parser-dir, -c <dir> Directory containing custom parsers
       --source-root, -s <dir>     Source root directory (can be specified multiple times).
                                   If not specified, derived from classpath.
+      --extra-source-root, -e <dir> Extra source root directory to add to auto-derived roots
+                                  (can be specified multiple times).
       --help, -h                 Show this help message
       """;
 
@@ -66,10 +68,16 @@ public class Main {
     // Derive source roots from classpath if not explicitly specified
     List<String> sourceRoots = options.sourceRoots;
     if (sourceRoots.isEmpty()) {
-      sourceRoots = nl.aerius.codegen.util.FileUtils.deriveSourceRootsFromClasspath();
+      sourceRoots = new ArrayList<>(nl.aerius.codegen.util.FileUtils.deriveSourceRootsFromClasspath());
       System.out.println("  Source roots (derived from classpath): " + sourceRoots);
     } else {
       System.out.println("  Source roots (explicitly specified): " + sourceRoots);
+    }
+
+    // Add extra source roots if specified
+    if (!options.extraSourceRoots.isEmpty()) {
+      sourceRoots.addAll(options.extraSourceRoots);
+      System.out.println("  Extra source roots: " + options.extraSourceRoots);
     }
     System.out.println();
 
@@ -135,6 +143,13 @@ public class Main {
           System.err.println("Missing value for --source-root");
           return null;
         }
+      } else if ("--extra-source-root".equals(arg) || "-e".equals(arg)) {
+        if (i + 1 < args.length) {
+          options.extraSourceRoots.add(args[++i]);
+        } else {
+          System.err.println("Missing value for --extra-source-root");
+          return null;
+        }
       } else {
         System.err.println("Unknown argument: " + arg);
         printUsage();
@@ -161,5 +176,6 @@ public class Main {
     String parserPackage;
     String customParserDir = null;
     List<String> sourceRoots = new ArrayList<>();
+    List<String> extraSourceRoots = new ArrayList<>();
   }
 }

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/Main.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/Main.java
@@ -16,6 +16,9 @@
  */
 package nl.aerius.codegen;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import nl.aerius.codegen.generator.ParserWriterUtils;
 import nl.aerius.codegen.util.ClassFinder;
 import nl.aerius.codegen.util.Logger;
@@ -61,7 +64,7 @@ public class Main {
         "  Custom parser directory: " + (options.customParserDir != null ? options.customParserDir : "not specified"));
 
     // Derive source roots from classpath if not explicitly specified
-    java.util.List<String> sourceRoots = options.sourceRoots;
+    List<String> sourceRoots = options.sourceRoots;
     if (sourceRoots.isEmpty()) {
       sourceRoots = nl.aerius.codegen.util.FileUtils.deriveSourceRootsFromClasspath();
       System.out.println("  Source roots (derived from classpath): " + sourceRoots);
@@ -157,6 +160,6 @@ public class Main {
     String outputDir;
     String parserPackage;
     String customParserDir = null;
-    java.util.List<String> sourceRoots = new java.util.ArrayList<>();
+    List<String> sourceRoots = new ArrayList<>();
   }
 }

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/ParserGenerator.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/ParserGenerator.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -26,7 +27,7 @@ public class ParserGenerator {
 
   public static void generateParsers(final String rootClassName, final String outputDir, final String parserPackage)
       throws IOException, ClassNotFoundException {
-    generateParsers(rootClassName, outputDir, parserPackage, null, new ClassFinder() {}, new Logger() {});
+    generateParsers(rootClassName, outputDir, parserPackage, null, List.of(), new ClassFinder() {}, new Logger() {});
   }
 
   /**
@@ -34,7 +35,7 @@ public class ParserGenerator {
    * determines generator info, and calls the generation logic.
    */
   public static void generateParsers(final String rootClassName, final String outputDir, final String parserPackage,
-      final String customParserDir, final ClassFinder classFinder, final Logger logger) throws IOException, ClassNotFoundException {
+      final String customParserDir, final List<String> sourceRoots, final ClassFinder classFinder, final Logger logger) throws IOException, ClassNotFoundException {
     // Load the root class
     final Class<?> rootClass = classFinder.forName(rootClassName);
 
@@ -50,7 +51,10 @@ public class ParserGenerator {
 
     // Validate if needed
     logger.info("Step 2: Validating " + rootClass.getName());
-    validateConfiguration(rootClass, customParserTypes, classFinder, logger);
+    validateConfiguration(rootClass, customParserTypes, sourceRoots, classFinder, logger);
+
+    // Set source roots for parser generation (needed for constructor-based types)
+    ParserWriterUtils.setSourceRoots(sourceRoots, logger);
 
     // Generate parsers
     logger.info("Step 3: Generating Parsers");
@@ -62,10 +66,11 @@ public class ParserGenerator {
     generateParsersForClass(rootClass, parserPackage, outputDir, customParserDir, generatorName, classFinder, logger);
   }
 
-  private static void validateConfiguration(final Class<?> rootClass, final Set<String> customParserTypes, final ClassFinder classFinder,
-      final Logger logger) {
+  private static void validateConfiguration(final Class<?> rootClass, final Set<String> customParserTypes, final List<String> sourceRoots,
+      final ClassFinder classFinder, final Logger logger) {
     final ConfigurationValidator validator = new ConfigurationValidator(classFinder, logger);
     validator.setCustomParserTypes(customParserTypes);
+    validator.setSourceRoots(sourceRoots);
     if (!validator.validate(rootClass)) {
       throw new IllegalStateException(rootClass.getName() + " validation failed. Please fix the issues before generating parsers.");
     }

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/analyzer/ConstructorAnalyzer.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/analyzer/ConstructorAnalyzer.java
@@ -304,22 +304,8 @@ public class ConstructorAnalyzer {
    * Checks if a source type name matches a reflection type.
    */
   private boolean typeNamesMatch(final String sourceTypeName, final Class<?> reflectionType) {
-    // Handle primitives
-    if (reflectionType.isPrimitive()) {
-      return sourceTypeName.equals(reflectionType.getName());
-    }
-
-    // Handle simple name match
-    if (sourceTypeName.equals(reflectionType.getSimpleName())) {
-      return true;
-    }
-
-    // Handle fully qualified name match
-    if (sourceTypeName.equals(reflectionType.getName())) {
-      return true;
-    }
-
-    return false;
+    return sourceTypeName.equals(reflectionType.getName())
+        || sourceTypeName.equals(reflectionType.getSimpleName());
   }
 
   /**

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/analyzer/ConstructorAnalyzer.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/analyzer/ConstructorAnalyzer.java
@@ -107,7 +107,17 @@ public class ConstructorAnalyzer {
     // Try to find source file and extract parameter names
     final Optional<CompilationUnit> sourceFile = findSourceFile(clazz);
     if (sourceFile.isEmpty()) {
-      logger.info("Source file not found for " + clazz.getName() + ", falling back to setter-based parsing");
+      // Only throw hard error if this class needs constructor-based parsing (no setters)
+      // For hasMatchingConstructor() calls (requireImmutable=false), just return empty
+      if (requireImmutable) {
+        if (sourceRoots.isEmpty()) {
+          throw new IllegalStateException("Cannot analyze constructor for " + clazz.getName()
+              + ": no source roots configured. Use --source-root option or ensure classpath contains target/classes directories.");
+        }
+        throw new IllegalStateException("Source file not found for " + clazz.getName()
+            + ". Searched in source roots: " + sourceRoots
+            + ". Ensure source files are available for constructor-based types.");
+      }
       return Optional.empty();
     }
 

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/analyzer/ConstructorAnalyzer.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/analyzer/ConstructorAnalyzer.java
@@ -108,6 +108,13 @@ public class ConstructorAnalyzer {
         // Find the matching reflection constructor
         final Constructor<?> matchingCtor = findMatchingReflectionConstructor(clazz, ctorDecl);
         if (matchingCtor != null) {
+          // Validate that constructor parameter types match field types
+          final String typeMismatch = validateParameterTypes(matchingCtor, paramNames, parseableFields);
+          if (typeMismatch != null) {
+            logger.warn("Constructor parameter type mismatch in " + clazz.getName() + ": " + typeMismatch);
+            continue; // Try next constructor
+          }
+
           logger.info("Found matching constructor for " + clazz.getName() +
               " with parameters: " + paramNames);
           return Optional.of(new ConstructorInfo(matchingCtor, paramNames, parseableFields));
@@ -116,6 +123,77 @@ public class ConstructorAnalyzer {
     }
 
     return Optional.empty();
+  }
+
+  /**
+   * Validates that constructor parameter types match the corresponding field types.
+   *
+   * @param ctor The constructor to validate
+   * @param paramNames The parameter names in order
+   * @param fields The list of parseable fields
+   * @return null if all types match, or an error message describing the mismatch
+   */
+  private String validateParameterTypes(final Constructor<?> ctor, final List<String> paramNames,
+      final List<Field> fields) {
+    final Class<?>[] paramTypes = ctor.getParameterTypes();
+
+    for (int i = 0; i < paramNames.size(); i++) {
+      final String paramName = paramNames.get(i);
+      final Class<?> paramType = paramTypes[i];
+
+      // Find the field with this name
+      Field matchingField = null;
+      for (final Field field : fields) {
+        if (field.getName().equals(paramName)) {
+          matchingField = field;
+          break;
+        }
+      }
+
+      if (matchingField == null) {
+        return "No field found for parameter '" + paramName + "'";
+      }
+
+      // Check if types match
+      if (!typesMatch(paramType, matchingField.getType())) {
+        return "Parameter '" + paramName + "' has type " + paramType.getSimpleName()
+            + " but field has type " + matchingField.getType().getSimpleName();
+      }
+    }
+
+    return null; // All types match
+  }
+
+  /**
+   * Checks if two types match, handling primitives and their wrappers.
+   */
+  private boolean typesMatch(final Class<?> paramType, final Class<?> fieldType) {
+    // Exact match
+    if (paramType.equals(fieldType)) {
+      return true;
+    }
+
+    // Check primitive/wrapper equivalence
+    if (paramType.isPrimitive() || fieldType.isPrimitive()) {
+      return getPrimitiveWrapper(paramType).equals(getPrimitiveWrapper(fieldType));
+    }
+
+    return false;
+  }
+
+  /**
+   * Returns the wrapper class for a primitive, or the class itself if not primitive.
+   */
+  private Class<?> getPrimitiveWrapper(final Class<?> type) {
+    if (type == boolean.class) return Boolean.class;
+    if (type == byte.class) return Byte.class;
+    if (type == char.class) return Character.class;
+    if (type == short.class) return Short.class;
+    if (type == int.class) return Integer.class;
+    if (type == long.class) return Long.class;
+    if (type == float.class) return Float.class;
+    if (type == double.class) return Double.class;
+    return type;
   }
 
   /**

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/analyzer/ConstructorAnalyzer.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/analyzer/ConstructorAnalyzer.java
@@ -40,13 +40,26 @@ public class ConstructorAnalyzer {
 
   /**
    * Checks if a class can use constructor-based parsing.
-   * Returns true if there exists a constructor with parameters matching all parseable fields.
+   * Returns true if there exists a constructor with parameters matching all parseable fields
+   * AND the class is immutable (does not have setters for all fields).
    *
    * @param clazz The class to check
    * @return true if constructor-based parsing can be used
    */
   public boolean canUseConstructorBasedParsing(final Class<?> clazz) {
     return findMatchingConstructorInfo(clazz).isPresent();
+  }
+
+  /**
+   * Checks if a class has a constructor that could be used for initialization.
+   * Unlike canUseConstructorBasedParsing(), this does NOT require the class to be immutable.
+   * Used for validation to determine if a no-arg constructor is required.
+   *
+   * @param clazz The class to check
+   * @return true if a matching constructor exists
+   */
+  public boolean hasMatchingConstructor(final Class<?> clazz) {
+    return findMatchingConstructorInfo(clazz, false).isPresent();
   }
 
   /**
@@ -57,13 +70,24 @@ public class ConstructorAnalyzer {
    * @return Optional containing constructor info if a matching constructor exists and class is immutable
    */
   public Optional<ConstructorInfo> findMatchingConstructorInfo(final Class<?> clazz) {
+    return findMatchingConstructorInfo(clazz, true);
+  }
+
+  /**
+   * Finds the constructor and its parameter order for constructor-based parsing.
+   *
+   * @param clazz The class to analyze
+   * @param requireImmutable If true, only returns a match if the class lacks setters for all fields
+   * @return Optional containing constructor info if a matching constructor exists
+   */
+  private Optional<ConstructorInfo> findMatchingConstructorInfo(final Class<?> clazz, final boolean requireImmutable) {
     final List<Field> parseableFields = getParseableFields(clazz);
     if (parseableFields.isEmpty()) {
       return Optional.empty();
     }
 
-    // Check if class has setters for all fields - if yes, prefer setter-based parsing
-    if (hasSettersForAllFields(clazz, parseableFields)) {
+    // Check if class has setters for all fields - if yes and requireImmutable, prefer setter-based parsing
+    if (requireImmutable && hasSettersForAllFields(clazz, parseableFields)) {
       return Optional.empty();
     }
 

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/analyzer/ConstructorAnalyzer.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/analyzer/ConstructorAnalyzer.java
@@ -1,0 +1,275 @@
+package nl.aerius.codegen.analyzer;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+
+import nl.aerius.codegen.util.Logger;
+
+/**
+ * Analyzes classes to determine if they should use constructor-based parsing.
+ * A class uses constructor-based parsing if:
+ * 1. It has a constructor whose parameters match all parseable fields by name
+ * 2. The class does NOT have setters for all those fields (i.e., it's immutable)
+ *
+ * If a class has setters for all fields, setter-based parsing is preferred
+ * for backwards compatibility.
+ */
+public class ConstructorAnalyzer {
+
+  private final List<String> sourceRoots;
+  private final Logger logger;
+
+  public ConstructorAnalyzer(final List<String> sourceRoots, final Logger logger) {
+    this.sourceRoots = sourceRoots != null ? sourceRoots : List.of();
+    this.logger = logger;
+  }
+
+  /**
+   * Checks if a class can use constructor-based parsing.
+   * Returns true if there exists a constructor with parameters matching all parseable fields.
+   *
+   * @param clazz The class to check
+   * @return true if constructor-based parsing can be used
+   */
+  public boolean canUseConstructorBasedParsing(final Class<?> clazz) {
+    return findMatchingConstructorInfo(clazz).isPresent();
+  }
+
+  /**
+   * Finds the constructor and its parameter order for constructor-based parsing.
+   * Only returns a match if the class is truly immutable (lacks setters for all fields).
+   *
+   * @param clazz The class to analyze
+   * @return Optional containing constructor info if a matching constructor exists and class is immutable
+   */
+  public Optional<ConstructorInfo> findMatchingConstructorInfo(final Class<?> clazz) {
+    final List<Field> parseableFields = getParseableFields(clazz);
+    if (parseableFields.isEmpty()) {
+      return Optional.empty();
+    }
+
+    // Check if class has setters for all fields - if yes, prefer setter-based parsing
+    if (hasSettersForAllFields(clazz, parseableFields)) {
+      return Optional.empty();
+    }
+
+    final Set<String> fieldNames = parseableFields.stream()
+        .map(Field::getName)
+        .collect(Collectors.toSet());
+
+    // First, find constructors with matching parameter count using reflection
+    final List<Constructor<?>> candidates = Arrays.stream(clazz.getDeclaredConstructors())
+        .filter(ctor -> ctor.getParameterCount() == parseableFields.size())
+        .collect(Collectors.toList());
+
+    if (candidates.isEmpty()) {
+      return Optional.empty();
+    }
+
+    // Try to find source file and extract parameter names
+    final Optional<CompilationUnit> sourceFile = findSourceFile(clazz);
+    if (sourceFile.isEmpty()) {
+      logger.info("Source file not found for " + clazz.getName() + ", falling back to setter-based parsing");
+      return Optional.empty();
+    }
+
+    // Find the class declaration in the source file
+    final Optional<ClassOrInterfaceDeclaration> classDecl = sourceFile.get()
+        .findFirst(ClassOrInterfaceDeclaration.class,
+            c -> c.getNameAsString().equals(clazz.getSimpleName()));
+
+    if (classDecl.isEmpty()) {
+      logger.info("Class declaration not found in source for " + clazz.getName());
+      return Optional.empty();
+    }
+
+    // Find a constructor with parameters matching all field names
+    for (final ConstructorDeclaration ctorDecl : classDecl.get().getConstructors()) {
+      final List<String> paramNames = ctorDecl.getParameters().stream()
+          .map(p -> p.getNameAsString())
+          .collect(Collectors.toList());
+
+      // Check if all parameter names match field names
+      if (paramNames.size() == fieldNames.size() && fieldNames.containsAll(paramNames)) {
+        // Find the matching reflection constructor
+        final Constructor<?> matchingCtor = findMatchingReflectionConstructor(clazz, ctorDecl);
+        if (matchingCtor != null) {
+          logger.info("Found matching constructor for " + clazz.getName() +
+              " with parameters: " + paramNames);
+          return Optional.of(new ConstructorInfo(matchingCtor, paramNames, parseableFields));
+        }
+      }
+    }
+
+    return Optional.empty();
+  }
+
+  /**
+   * Gets all fields that should be parsed (non-static, non-transient, non-synthetic).
+   */
+  public static List<Field> getParseableFields(final Class<?> clazz) {
+    final List<Field> fields = new ArrayList<>();
+    for (final Field field : clazz.getDeclaredFields()) {
+      if (!Modifier.isStatic(field.getModifiers())
+          && !Modifier.isTransient(field.getModifiers())
+          && !field.isSynthetic()) {
+        fields.add(field);
+      }
+    }
+    return fields;
+  }
+
+  /**
+   * Checks if a class has setter methods for all parseable fields.
+   * If true, setter-based parsing is preferred over constructor-based.
+   */
+  private boolean hasSettersForAllFields(final Class<?> clazz, final List<Field> fields) {
+    for (final Field field : fields) {
+      final String setterName = "set" + capitalize(field.getName());
+      try {
+        clazz.getMethod(setterName, field.getType());
+      } catch (final NoSuchMethodException e) {
+        // No setter for this field - class is not fully mutable
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Capitalizes the first character of a string.
+   */
+  private static String capitalize(final String str) {
+    if (str == null || str.isEmpty()) {
+      return str;
+    }
+    return Character.toUpperCase(str.charAt(0)) + str.substring(1);
+  }
+
+  /**
+   * Finds the reflection Constructor that matches the JavaParser ConstructorDeclaration.
+   */
+  private Constructor<?> findMatchingReflectionConstructor(final Class<?> clazz,
+      final ConstructorDeclaration ctorDecl) {
+    final int paramCount = ctorDecl.getParameters().size();
+
+    for (final Constructor<?> ctor : clazz.getDeclaredConstructors()) {
+      if (ctor.getParameterCount() == paramCount) {
+        // Match by parameter types
+        boolean matches = true;
+        for (int i = 0; i < paramCount; i++) {
+          final String sourceTypeName = ctorDecl.getParameter(i).getType().asString();
+          final Class<?> reflectionType = ctor.getParameterTypes()[i];
+
+          if (!typeNamesMatch(sourceTypeName, reflectionType)) {
+            matches = false;
+            break;
+          }
+        }
+        if (matches) {
+          return ctor;
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Checks if a source type name matches a reflection type.
+   */
+  private boolean typeNamesMatch(final String sourceTypeName, final Class<?> reflectionType) {
+    // Handle primitives
+    if (reflectionType.isPrimitive()) {
+      return sourceTypeName.equals(reflectionType.getName());
+    }
+
+    // Handle simple name match
+    if (sourceTypeName.equals(reflectionType.getSimpleName())) {
+      return true;
+    }
+
+    // Handle fully qualified name match
+    if (sourceTypeName.equals(reflectionType.getName())) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Finds the source file for the given class.
+   */
+  private Optional<CompilationUnit> findSourceFile(final Class<?> clazz) {
+    final String relativePath = clazz.getName().replace('.', '/') + ".java";
+
+    for (final String sourceRoot : sourceRoots) {
+      final Path sourcePath = Path.of(sourceRoot, relativePath);
+      if (sourcePath.toFile().exists()) {
+        try {
+          return Optional.of(StaticJavaParser.parse(sourcePath));
+        } catch (final Exception e) {
+          logger.warn("Failed to parse source file: " + sourcePath + " - " + e.getMessage());
+        }
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Contains information about a constructor suitable for constructor-based parsing.
+   */
+  public static class ConstructorInfo {
+    private final Constructor<?> constructor;
+    private final List<String> parameterNames;
+    private final List<Field> fields;
+
+    public ConstructorInfo(final Constructor<?> constructor, final List<String> parameterNames,
+        final List<Field> fields) {
+      this.constructor = constructor;
+      this.parameterNames = parameterNames;
+      this.fields = fields;
+    }
+
+    public Constructor<?> getConstructor() {
+      return constructor;
+    }
+
+    public List<String> getParameterNames() {
+      return parameterNames;
+    }
+
+    public List<Field> getFields() {
+      return fields;
+    }
+
+    /**
+     * Returns fields in the order they appear in the constructor parameters.
+     */
+    public List<Field> getFieldsInConstructorOrder() {
+      final List<Field> ordered = new ArrayList<>();
+      for (final String paramName : parameterNames) {
+        for (final Field field : fields) {
+          if (field.getName().equals(paramName)) {
+            ordered.add(field);
+            break;
+          }
+        }
+      }
+      return ordered;
+    }
+  }
+}

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/analyzer/ConstructorAnalyzer.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/analyzer/ConstructorAnalyzer.java
@@ -327,47 +327,4 @@ public class ConstructorAnalyzer {
     return Optional.empty();
   }
 
-  /**
-   * Contains information about a constructor suitable for constructor-based parsing.
-   */
-  public static class ConstructorInfo {
-    private final Constructor<?> constructor;
-    private final List<String> parameterNames;
-    private final List<Field> fields;
-
-    public ConstructorInfo(final Constructor<?> constructor, final List<String> parameterNames,
-        final List<Field> fields) {
-      this.constructor = constructor;
-      this.parameterNames = parameterNames;
-      this.fields = fields;
-    }
-
-    public Constructor<?> getConstructor() {
-      return constructor;
-    }
-
-    public List<String> getParameterNames() {
-      return parameterNames;
-    }
-
-    public List<Field> getFields() {
-      return fields;
-    }
-
-    /**
-     * Returns fields in the order they appear in the constructor parameters.
-     */
-    public List<Field> getFieldsInConstructorOrder() {
-      final List<Field> ordered = new ArrayList<>();
-      for (final String paramName : parameterNames) {
-        for (final Field field : fields) {
-          if (field.getName().equals(paramName)) {
-            ordered.add(field);
-            break;
-          }
-        }
-      }
-      return ordered;
-    }
-  }
 }

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/analyzer/ConstructorInfo.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/analyzer/ConstructorInfo.java
@@ -1,0 +1,50 @@
+package nl.aerius.codegen.analyzer;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Contains information about a constructor suitable for constructor-based parsing.
+ */
+public class ConstructorInfo {
+  private final Constructor<?> constructor;
+  private final List<String> parameterNames;
+  private final List<Field> fields;
+
+  public ConstructorInfo(final Constructor<?> constructor, final List<String> parameterNames,
+      final List<Field> fields) {
+    this.constructor = constructor;
+    this.parameterNames = parameterNames;
+    this.fields = fields;
+  }
+
+  public Constructor<?> getConstructor() {
+    return constructor;
+  }
+
+  public List<String> getParameterNames() {
+    return parameterNames;
+  }
+
+  public List<Field> getFields() {
+    return fields;
+  }
+
+  /**
+   * Returns fields in the order they appear in the constructor parameters.
+   */
+  public List<Field> getFieldsInConstructorOrder() {
+    final List<Field> ordered = new ArrayList<>();
+    for (final String paramName : parameterNames) {
+      for (final Field field : fields) {
+        if (field.getName().equals(paramName)) {
+          ordered.add(field);
+          break;
+        }
+      }
+    }
+    return ordered;
+  }
+}

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriterUtils.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriterUtils.java
@@ -454,6 +454,10 @@ public final class ParserWriterUtils {
       return CodeBlock.of("(short) $L.getInteger($S)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
     } else if (fieldClass == char.class || fieldClass == Character.class) {
       return CodeBlock.of("$L.getString($S).charAt(0)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
+    } else if (fieldClass.isEnum()) {
+      // Enum handling - use valueOf
+      return CodeBlock.of("$T.valueOf($L.getString($S))",
+          fieldClass, ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
     } else {
       // For custom objects, delegate to their parser
       return CodeBlock.of("$LParser.parse($L.getObject($S))",

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriterUtils.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriterUtils.java
@@ -8,7 +8,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.lang.model.element.Modifier;
 
@@ -20,6 +22,8 @@ import com.palantir.javapoet.JavaFile;
 import com.palantir.javapoet.MethodSpec;
 import com.palantir.javapoet.TypeSpec;
 
+import nl.aerius.codegen.analyzer.ConstructorAnalyzer;
+import nl.aerius.codegen.analyzer.ConstructorAnalyzer.ConstructorInfo;
 import nl.aerius.codegen.generator.parser.CollectionFieldParser;
 import nl.aerius.codegen.generator.parser.CustomObjectFieldParser;
 import nl.aerius.codegen.generator.parser.EnumFieldParser;
@@ -61,8 +65,22 @@ public final class ParserWriterUtils {
   private static TypeParser collectionFieldParser;
   private static TypeParser mapFieldParser;
 
+  // Constructor analyzer for detecting constructor-based parsing
+  private static ConstructorAnalyzer constructorAnalyzer;
+
   private ParserWriterUtils() {
     // Utility class, no instantiation
+  }
+
+  /**
+   * Sets the source roots for constructor analysis.
+   * Must be called before generating parsers for constructor-based types.
+   *
+   * @param sourceRoots List of source root directories to search for source files
+   * @param logger Logger instance for messages
+   */
+  public static void setSourceRoots(final List<String> sourceRoots, final Logger logger) {
+    constructorAnalyzer = new ConstructorAnalyzer(sourceRoots, logger);
   }
 
   public static void initParsers(final ClassFinder classFinder, final Logger logger) {
@@ -102,18 +120,40 @@ public final class ParserWriterUtils {
   /**
    * Main entry point for generating a parser class.
    * Creates both parse(String) and parse(JSONObjectHandle) methods.
+   * For constructor-based types (no setters), generates constructor-based parse method.
    * @param classFinder
    */
   public static void generateParserForFields(final TypeSpec.Builder typeSpec, final Class<?> targetClass, final String parserPackage,
       final ClassFinder classFinder) {
     typeSpec.addMethod(createStringParseMethod(targetClass));
-    // Decide which kind of object parse method to generate based on polymorphism
-    if (hasJsonTypeInfoWithNameDiscriminator(targetClass)) {
-      typeSpec.addMethod(createPolymorphicObjectParseMethod(targetClass, parserPackage));
+
+    // Check if this class should use constructor-based parsing
+    final Optional<ConstructorInfo> constructorInfo = findConstructorInfo(targetClass);
+
+    if (constructorInfo.isPresent()) {
+      // Constructor-based: single parse method that constructs the object
+      typeSpec.addMethod(createConstructorBasedParseMethod(targetClass, parserPackage, classFinder, constructorInfo.get()));
+      // No config-based parse method for immutable types
     } else {
-      typeSpec.addMethod(createStandardObjectParseMethod(targetClass, parserPackage));
+      // Setter-based: existing approach
+      // Decide which kind of object parse method to generate based on polymorphism
+      if (hasJsonTypeInfoWithNameDiscriminator(targetClass)) {
+        typeSpec.addMethod(createPolymorphicObjectParseMethod(targetClass, parserPackage));
+      } else {
+        typeSpec.addMethod(createStandardObjectParseMethod(targetClass, parserPackage));
+      }
+      typeSpec.addMethod(createConfigParseMethod(targetClass, parserPackage, classFinder));
     }
-    typeSpec.addMethod(createConfigParseMethod(targetClass, parserPackage, classFinder));
+  }
+
+  /**
+   * Finds constructor info for a class, if constructor-based parsing is available.
+   */
+  private static Optional<ConstructorInfo> findConstructorInfo(final Class<?> targetClass) {
+    if (constructorAnalyzer == null) {
+      return Optional.empty();
+    }
+    return constructorAnalyzer.findMatchingConstructorInfo(targetClass);
   }
 
   /**
@@ -322,6 +362,103 @@ public final class ParserWriterUtils {
     methodBuilder.endControlFlow(); // End switch
 
     return methodBuilder.build();
+  }
+
+  /**
+   * Creates a constructor-based parse method for immutable types.
+   * Parses all fields into local variables and then calls the constructor.
+   */
+  private static MethodSpec createConstructorBasedParseMethod(final Class<?> targetClass, final String parserPackage,
+      final ClassFinder classFinder, final ConstructorInfo constructorInfo) {
+    final ClassName targetClassName = ClassName.get(targetClass);
+    final MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder("parse")
+        .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+        .returns(targetClassName)
+        .addParameter(ParserCommonUtils.getJSONObjectHandle(), ParserCommonUtils.BASE_OBJECT_PARAM_NAME, Modifier.FINAL);
+
+    methodBuilder.beginControlFlow("if ($L == null)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME)
+        .addStatement("return null")
+        .endControlFlow();
+
+    // Get fields in constructor parameter order
+    final List<Field> fieldsInOrder = constructorInfo.getFieldsInConstructorOrder();
+    final List<String> paramNames = constructorInfo.getParameterNames();
+
+    // Parse each field into a local variable with the field's name
+    for (final Field field : fieldsInOrder) {
+      methodBuilder.addCode("\n");
+      methodBuilder.addComment("Parse $L", field.getName());
+
+      // Check if field is required (must exist in JSON)
+      methodBuilder.beginControlFlow("if (!$L.has($S))", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, field.getName())
+          .addStatement("throw new $T($S)", RuntimeException.class,
+              "Required field '" + field.getName() + "' is missing")
+          .endControlFlow();
+
+      final Class<?> fieldClass = field.getType();
+      final boolean isPrimitive = fieldClass.isPrimitive();
+      final String fieldName = field.getName();
+
+      if (isPrimitive) {
+        // Primitives can be parsed directly (no null check needed)
+        final CodeBlock getter = createSimpleGetter(fieldClass, fieldName);
+        methodBuilder.addStatement("final $T $L = $L", fieldClass, fieldName, getter);
+      } else {
+        // Non-primitives need null handling
+        methodBuilder.addStatement("final $T $L", fieldClass, fieldName);
+        methodBuilder.beginControlFlow("if (!$L.isNull($S))", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
+        final CodeBlock getter = createSimpleGetter(fieldClass, fieldName);
+        methodBuilder.addStatement("$L = $L", fieldName, getter);
+        methodBuilder.nextControlFlow("else");
+        methodBuilder.addStatement("$L = null", fieldName);
+        methodBuilder.endControlFlow();
+      }
+    }
+
+    // Build constructor call with all parameters in order
+    final StringBuilder constructorArgs = new StringBuilder();
+    for (int i = 0; i < paramNames.size(); i++) {
+      if (i > 0) {
+        constructorArgs.append(", ");
+      }
+      constructorArgs.append(paramNames.get(i));
+    }
+
+    methodBuilder.addCode("\n");
+    methodBuilder.addStatement("return new $T($L)", targetClass, constructorArgs.toString());
+
+    return methodBuilder.build();
+  }
+
+  /**
+   * Creates a simple getter expression for a field type.
+   */
+  private static CodeBlock createSimpleGetter(final Class<?> fieldClass, final String fieldName) {
+    if (fieldClass == String.class) {
+      return CodeBlock.of("$L.getString($S)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
+    } else if (fieldClass == int.class || fieldClass == Integer.class) {
+      return CodeBlock.of("$L.getInteger($S)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
+    } else if (fieldClass == long.class || fieldClass == Long.class) {
+      return CodeBlock.of("$L.getLong($S)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
+    } else if (fieldClass == double.class) {
+      return CodeBlock.of("$L.getNumber($S)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
+    } else if (fieldClass == Double.class) {
+      return CodeBlock.of("$L.getNumber($S)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
+    } else if (fieldClass == boolean.class || fieldClass == Boolean.class) {
+      return CodeBlock.of("$L.getBoolean($S)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
+    } else if (fieldClass == float.class || fieldClass == Float.class) {
+      return CodeBlock.of("$L.getNumber($S).floatValue()", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
+    } else if (fieldClass == byte.class || fieldClass == Byte.class) {
+      return CodeBlock.of("(byte) $L.getInteger($S)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
+    } else if (fieldClass == short.class || fieldClass == Short.class) {
+      return CodeBlock.of("(short) $L.getInteger($S)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
+    } else if (fieldClass == char.class || fieldClass == Character.class) {
+      return CodeBlock.of("$L.getString($S).charAt(0)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
+    } else {
+      // For custom objects, delegate to their parser
+      return CodeBlock.of("$LParser.parse($L.getObject($S))",
+          fieldClass.getSimpleName(), ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
+    }
   }
 
   private static MethodSpec createConfigParseMethod(final Class<?> targetClass, final String parserPackage, final ClassFinder classFinder) {

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriterUtils.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriterUtils.java
@@ -440,9 +440,7 @@ public final class ParserWriterUtils {
       return CodeBlock.of("$L.getInteger($S)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
     } else if (fieldClass == long.class || fieldClass == Long.class) {
       return CodeBlock.of("$L.getLong($S)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
-    } else if (fieldClass == double.class) {
-      return CodeBlock.of("$L.getNumber($S)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
-    } else if (fieldClass == Double.class) {
+    } else if (fieldClass == double.class || fieldClass == Double.class) {
       return CodeBlock.of("$L.getNumber($S)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
     } else if (fieldClass == boolean.class || fieldClass == Boolean.class) {
       return CodeBlock.of("$L.getBoolean($S)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriterUtils.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriterUtils.java
@@ -7,6 +7,7 @@ import java.lang.reflect.Type;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -382,9 +383,9 @@ public final class ParserWriterUtils {
 
     // Get fields in constructor parameter order
     final List<Field> fieldsInOrder = constructorInfo.getFieldsInConstructorOrder();
-    final List<String> paramNames = constructorInfo.getParameterNames();
+    final List<String> constructorArgVars = new ArrayList<>();
 
-    // Parse each field into a local variable with the field's name
+    // Parse each field using existing TypeParser infrastructure
     for (final Field field : fieldsInOrder) {
       methodBuilder.addCode("\n");
       methodBuilder.addComment("Parse $L", field.getName());
@@ -395,72 +396,32 @@ public final class ParserWriterUtils {
               "Required field '" + field.getName() + "' is missing")
           .endControlFlow();
 
-      final Class<?> fieldClass = field.getType();
-      final boolean isPrimitive = fieldClass.isPrimitive();
-      final String fieldName = field.getName();
+      // Create access expression for this field
+      final CodeBlock fieldAccess = ParserCommonUtils.createFieldAccessCode(
+          field.getGenericType(),
+          ParserCommonUtils.BASE_OBJECT_PARAM_NAME,
+          CodeBlock.of("$S", field.getName()));
 
-      if (isPrimitive) {
-        // Primitives can be parsed directly (no null check needed)
-        final CodeBlock getter = createSimpleGetter(fieldClass, fieldName);
-        methodBuilder.addStatement("final $T $L = $L", fieldClass, fieldName, getter);
-      } else {
-        // Non-primitives need null handling
-        methodBuilder.addStatement("final $T $L", fieldClass, fieldName);
-        methodBuilder.beginControlFlow("if (!$L.isNull($S))", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
-        final CodeBlock getter = createSimpleGetter(fieldClass, fieldName);
-        methodBuilder.addStatement("$L = $L", fieldName, getter);
-        methodBuilder.nextControlFlow("else");
-        methodBuilder.addStatement("$L = null", fieldName);
-        methodBuilder.endControlFlow();
-      }
-    }
+      // Use existing TypeParser infrastructure to generate parsing code with field name as variable name
+      final CodeBlock.Builder parseCode = CodeBlock.builder();
+      final String resultVar = dispatchGenerateParsingCodeInto(
+          parseCode,
+          field.getGenericType(),
+          ParserCommonUtils.BASE_OBJECT_PARAM_NAME,
+          parserPackage,
+          fieldAccess,
+          1,
+          field.getGenericType(),
+          field.getName()); // Pass field name as variable name
 
-    // Build constructor call with all parameters in order
-    final StringBuilder constructorArgs = new StringBuilder();
-    for (int i = 0; i < paramNames.size(); i++) {
-      if (i > 0) {
-        constructorArgs.append(", ");
-      }
-      constructorArgs.append(paramNames.get(i));
+      methodBuilder.addCode(parseCode.build());
+      constructorArgVars.add(resultVar);
     }
 
     methodBuilder.addCode("\n");
-    methodBuilder.addStatement("return new $T($L)", targetClass, constructorArgs.toString());
+    methodBuilder.addStatement("return new $T($L)", targetClass, String.join(", ", constructorArgVars));
 
     return methodBuilder.build();
-  }
-
-  /**
-   * Creates a simple getter expression for a field type.
-   */
-  private static CodeBlock createSimpleGetter(final Class<?> fieldClass, final String fieldName) {
-    if (fieldClass == String.class) {
-      return CodeBlock.of("$L.getString($S)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
-    } else if (fieldClass == int.class || fieldClass == Integer.class) {
-      return CodeBlock.of("$L.getInteger($S)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
-    } else if (fieldClass == long.class || fieldClass == Long.class) {
-      return CodeBlock.of("$L.getLong($S)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
-    } else if (fieldClass == double.class || fieldClass == Double.class) {
-      return CodeBlock.of("$L.getNumber($S)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
-    } else if (fieldClass == boolean.class || fieldClass == Boolean.class) {
-      return CodeBlock.of("$L.getBoolean($S)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
-    } else if (fieldClass == float.class || fieldClass == Float.class) {
-      return CodeBlock.of("$L.getNumber($S).floatValue()", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
-    } else if (fieldClass == byte.class || fieldClass == Byte.class) {
-      return CodeBlock.of("(byte) $L.getInteger($S)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
-    } else if (fieldClass == short.class || fieldClass == Short.class) {
-      return CodeBlock.of("(short) $L.getInteger($S)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
-    } else if (fieldClass == char.class || fieldClass == Character.class) {
-      return CodeBlock.of("$L.getString($S).charAt(0)", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
-    } else if (fieldClass.isEnum()) {
-      // Enum handling - use valueOf
-      return CodeBlock.of("$T.valueOf($L.getString($S))",
-          fieldClass, ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
-    } else {
-      // For custom objects, delegate to their parser
-      return CodeBlock.of("$LParser.parse($L.getObject($S))",
-          fieldClass.getSimpleName(), ParserCommonUtils.BASE_OBJECT_PARAM_NAME, fieldName);
-    }
   }
 
   private static MethodSpec createConfigParseMethod(final Class<?> targetClass, final String parserPackage, final ClassFinder classFinder) {
@@ -555,18 +516,23 @@ public final class ParserWriterUtils {
   public static String dispatchGenerateParsingCodeInto(final CodeBlock.Builder code, final Type type, final String objVarName,
       final String parserPackage,
       final CodeBlock accessExpression, final int level, final Type fieldType) {
+    return dispatchGenerateParsingCodeInto(code, type, objVarName, parserPackage, accessExpression, level, fieldType, null);
+  }
+
+  /**
+   * Dispatches parsing logic to the appropriate TypeParser with an optional variable name override.
+   */
+  public static String dispatchGenerateParsingCodeInto(final CodeBlock.Builder code, final Type type, final String objVarName,
+      final String parserPackage, final CodeBlock accessExpression, final int level, final Type fieldType, final String variableName) {
     for (final TypeParser parser : PARSERS) {
       if (parser.canHandle(type)) {
-        // Call 7-parameter version
-        return parser.generateParsingCodeInto(code, type, objVarName, parserPackage, accessExpression, level, fieldType);
+        return parser.generateParsingCodeInto(code, type, objVarName, parserPackage, accessExpression, level, fieldType, variableName);
       }
     }
 
     // If no parser handled the type, add a placeholder or throw an error
-    final String placeholderVar = "level" + level + "UnsupportedValue";
+    final String placeholderVar = variableName != null ? variableName : "level" + level + "UnsupportedValue";
     code.addStatement("$T $L = null; // Type not supported: $L", Object.class, placeholderVar, type.getTypeName());
-    // Alternatively, throw an exception:
-    // throw new IllegalArgumentException("No parser found for type: " + type.getTypeName());
     return placeholderVar;
   }
 

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriterUtils.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriterUtils.java
@@ -24,7 +24,7 @@ import com.palantir.javapoet.MethodSpec;
 import com.palantir.javapoet.TypeSpec;
 
 import nl.aerius.codegen.analyzer.ConstructorAnalyzer;
-import nl.aerius.codegen.analyzer.ConstructorAnalyzer.ConstructorInfo;
+import nl.aerius.codegen.analyzer.ConstructorInfo;
 import nl.aerius.codegen.generator.parser.CollectionFieldParser;
 import nl.aerius.codegen.generator.parser.CustomObjectFieldParser;
 import nl.aerius.codegen.generator.parser.EnumFieldParser;
@@ -134,17 +134,23 @@ public final class ParserWriterUtils {
     if (constructorInfo.isPresent()) {
       // Constructor-based: single parse method that constructs the object
       typeSpec.addMethod(createConstructorBasedParseMethod(targetClass, parserPackage, classFinder, constructorInfo.get()));
-      // No config-based parse method for immutable types
     } else {
       // Setter-based: existing approach
-      // Decide which kind of object parse method to generate based on polymorphism
-      if (hasJsonTypeInfoWithNameDiscriminator(targetClass)) {
-        typeSpec.addMethod(createPolymorphicObjectParseMethod(targetClass, parserPackage));
-      } else {
-        typeSpec.addMethod(createStandardObjectParseMethod(targetClass, parserPackage));
-      }
-      typeSpec.addMethod(createConfigParseMethod(targetClass, parserPackage, classFinder));
+      addSetterBasedParseMethods(typeSpec, targetClass, parserPackage, classFinder);
     }
+  }
+
+  /**
+   * Adds setter-based parse methods to the type specification.
+   */
+  private static void addSetterBasedParseMethods(final TypeSpec.Builder typeSpec, final Class<?> targetClass,
+      final String parserPackage, final ClassFinder classFinder) {
+    if (hasJsonTypeInfoWithNameDiscriminator(targetClass)) {
+      typeSpec.addMethod(createPolymorphicObjectParseMethod(targetClass, parserPackage));
+    } else {
+      typeSpec.addMethod(createStandardObjectParseMethod(targetClass, parserPackage));
+    }
+    typeSpec.addMethod(createConfigParseMethod(targetClass, parserPackage, classFinder));
   }
 
   /**
@@ -387,34 +393,7 @@ public final class ParserWriterUtils {
 
     // Parse each field using existing TypeParser infrastructure
     for (final Field field : fieldsInOrder) {
-      methodBuilder.addCode("\n");
-      methodBuilder.addComment("Parse $L", field.getName());
-
-      // Check if field is required (must exist in JSON)
-      methodBuilder.beginControlFlow("if (!$L.has($S))", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, field.getName())
-          .addStatement("throw new $T($S)", RuntimeException.class,
-              "Required field '" + field.getName() + "' is missing")
-          .endControlFlow();
-
-      // Create access expression for this field
-      final CodeBlock fieldAccess = ParserCommonUtils.createFieldAccessCode(
-          field.getGenericType(),
-          ParserCommonUtils.BASE_OBJECT_PARAM_NAME,
-          CodeBlock.of("$S", field.getName()));
-
-      // Use existing TypeParser infrastructure to generate parsing code with field name as variable name
-      final CodeBlock.Builder parseCode = CodeBlock.builder();
-      final String resultVar = dispatchGenerateParsingCodeInto(
-          parseCode,
-          field.getGenericType(),
-          ParserCommonUtils.BASE_OBJECT_PARAM_NAME,
-          parserPackage,
-          fieldAccess,
-          1,
-          field.getGenericType(),
-          field.getName()); // Pass field name as variable name
-
-      methodBuilder.addCode(parseCode.build());
+      final String resultVar = generateFieldParsingCode(methodBuilder, field, parserPackage);
       constructorArgVars.add(resultVar);
     }
 
@@ -422,6 +401,42 @@ public final class ParserWriterUtils {
     methodBuilder.addStatement("return new $T($L)", targetClass, String.join(", ", constructorArgVars));
 
     return methodBuilder.build();
+  }
+
+  /**
+   * Generates parsing code for a single field in a constructor-based parser.
+   */
+  private static String generateFieldParsingCode(final MethodSpec.Builder methodBuilder, final Field field,
+      final String parserPackage) {
+    methodBuilder.addCode("\n");
+    methodBuilder.addComment("Parse $L", field.getName());
+
+    // Check if field is required (must exist in JSON)
+    methodBuilder.beginControlFlow("if (!$L.has($S))", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, field.getName())
+        .addStatement("throw new $T($S)", RuntimeException.class,
+            "Required field '" + field.getName() + "' is missing")
+        .endControlFlow();
+
+    // Create access expression for this field
+    final CodeBlock fieldAccess = ParserCommonUtils.createFieldAccessCode(
+        field.getGenericType(),
+        ParserCommonUtils.BASE_OBJECT_PARAM_NAME,
+        CodeBlock.of("$S", field.getName()));
+
+    // Use existing TypeParser infrastructure to generate parsing code with field name as variable name
+    final CodeBlock.Builder parseCode = CodeBlock.builder();
+    final String resultVar = dispatchGenerateParsingCodeInto(
+        parseCode,
+        field.getGenericType(),
+        ParserCommonUtils.BASE_OBJECT_PARAM_NAME,
+        parserPackage,
+        fieldAccess,
+        1,
+        field.getGenericType(),
+        field.getName());
+
+    methodBuilder.addCode(parseCode.build());
+    return resultVar;
   }
 
   private static MethodSpec createConfigParseMethod(final Class<?> targetClass, final String parserPackage, final ClassFinder classFinder) {

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/CustomObjectFieldParser.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/CustomObjectFieldParser.java
@@ -52,6 +52,12 @@ public class CustomObjectFieldParser implements TypeParser {
   @Override
   public String generateParsingCodeInto(CodeBlock.Builder code, Type type, String objVarName, String parserPackage, CodeBlock accessExpression,
       int level, Type fieldType) {
+    return generateParsingCodeInto(code, type, objVarName, parserPackage, accessExpression, level, fieldType, null);
+  }
+
+  @Override
+  public String generateParsingCodeInto(CodeBlock.Builder code, Type type, String objVarName, String parserPackage, CodeBlock accessExpression,
+      int level, Type fieldType, String variableName) {
     if (!canHandle(type)) {
       throw new IllegalArgumentException("CustomObjectFieldParser cannot handle type: " + type.getTypeName());
     }
@@ -80,7 +86,7 @@ public class CustomObjectFieldParser implements TypeParser {
       parserClassName = ClassName.get(parserPackage, parserSimpleName);
     }
 
-    String resultVarName = ParserCommonUtils.getVariableNameForLevel(level, "value");
+    String resultVarName = variableName != null ? variableName : ParserCommonUtils.getVariableNameForLevel(level, "value");
 
     code.addStatement("final $T $L = $T.parse($L)", fieldType, resultVarName, parserClassName, accessExpression);
 

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/EnumFieldParser.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/EnumFieldParser.java
@@ -45,8 +45,7 @@ public class EnumFieldParser implements TypeParser {
 
   @Override
   public String generateParsingCodeInto(final CodeBlock.Builder code, final Type type, final String objVarName, final String parserPackage,
-      final CodeBlock accessExpression,
-      final int level, final Type fieldType, final String variableName) {
+      final CodeBlock accessExpression, final int level, final Type fieldType, final String variableName) {
     if (!canHandle(type)) {
       throw new IllegalArgumentException("EnumFieldParser cannot handle type: " + type.getTypeName());
     }

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/EnumFieldParser.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/EnumFieldParser.java
@@ -40,12 +40,19 @@ public class EnumFieldParser implements TypeParser {
   public String generateParsingCodeInto(final CodeBlock.Builder code, final Type type, final String objVarName, final String parserPackage,
       final CodeBlock accessExpression,
       final int level, final Type fieldType) {
+    return generateParsingCodeInto(code, type, objVarName, parserPackage, accessExpression, level, fieldType, null);
+  }
+
+  @Override
+  public String generateParsingCodeInto(final CodeBlock.Builder code, final Type type, final String objVarName, final String parserPackage,
+      final CodeBlock accessExpression,
+      final int level, final Type fieldType, final String variableName) {
     if (!canHandle(type)) {
       throw new IllegalArgumentException("EnumFieldParser cannot handle type: " + type.getTypeName());
     }
     final Class<?> enumType = (Class<?>) type;
-    final String resultVarName = ParserCommonUtils.getVariableNameForLevel(level, "value");
-    final String strVarName = ParserCommonUtils.getVariableNameForLevel(level, "str");
+    final String resultVarName = variableName != null ? variableName : ParserCommonUtils.getVariableNameForLevel(level, "value");
+    final String strVarName = variableName != null ? variableName + "Str" : ParserCommonUtils.getVariableNameForLevel(level, "str");
 
     // Find a potential @JsonCreator method using the common utility
     final Method jsonCreatorMethod = ParserCommonUtils.findJsonCreatorMethod(enumType, classFinder, logger);

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/SimpleFieldParser.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/SimpleFieldParser.java
@@ -53,11 +53,17 @@ public class SimpleFieldParser implements TypeParser {
   @Override
   public String generateParsingCodeInto(CodeBlock.Builder code, Type type, String objVarName, String parserPackage, CodeBlock accessExpression,
       int level, Type fieldType) {
+    return generateParsingCodeInto(code, type, objVarName, parserPackage, accessExpression, level, fieldType, null);
+  }
+
+  @Override
+  public String generateParsingCodeInto(CodeBlock.Builder code, Type type, String objVarName, String parserPackage, CodeBlock accessExpression,
+      int level, Type fieldType, String variableName) {
     if (!canHandle(type)) {
       throw new IllegalArgumentException("SimpleFieldParser cannot handle type: " + type.getTypeName());
     }
     Class<?> clazz = (Class<?>) type;
-    String resultVarName = ParserCommonUtils.getVariableNameForLevel(level, "value");
+    String resultVarName = variableName != null ? variableName : ParserCommonUtils.getVariableNameForLevel(level, "value");
     String tempStringVar = ParserCommonUtils.getVariableNameForLevel(level, "str");
 
     if (clazz.equals(char.class) || clazz.equals(Character.class)) {

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/TypeParser.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/TypeParser.java
@@ -60,14 +60,14 @@ public interface TypeParser {
      * Default implementation delegates to the standard method, ignoring the variable name.
      * Implementations can override this to use the provided variable name.
      *
-     * @param code              The CodeBlock.Builder to add generated code to.
-     * @param type              The runtime Type being parsed.
-     * @param objVarName        The variable name of the parent JSONObjectHandle.
-     * @param parserPackage     The package for generated parsers.
-     * @param accessExpression  A CodeBlock representing how to access the raw JSON data.
-     * @param level             The current nesting level.
-     * @param fieldType         The exact generic type of the original field/setter parameter.
-     * @param variableName      The desired variable name for the parsed value, or null for default naming.
+     * @param code The CodeBlock.Builder to add generated code to.
+     * @param type The runtime Type being parsed.
+     * @param objVarName The variable name of the parent JSONObjectHandle.
+     * @param parserPackage The package for generated parsers.
+     * @param accessExpression A CodeBlock representing how to access the raw JSON data.
+     * @param level The current nesting level.
+     * @param fieldType The exact generic type of the original field/setter parameter.
+     * @param variableName The desired variable name for the parsed value, or null for default naming.
      * @return The name of the variable declared within the generated code block.
      */
     default String generateParsingCodeInto(CodeBlock.Builder code, Type type, String objVarName, String parserPackage,
@@ -75,4 +75,4 @@ public interface TypeParser {
         // Default: ignore variableName and use standard method
         return generateParsingCodeInto(code, type, objVarName, parserPackage, accessExpression, level, fieldType);
     }
-} 
+}

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/TypeParser.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/TypeParser.java
@@ -54,4 +54,25 @@ public interface TypeParser {
      */
     String generateParsingCodeInto(CodeBlock.Builder code, Type type, String objVarName, String parserPackage,
         CodeBlock accessExpression, int level, Type fieldType);
+
+    /**
+     * Generates parsing code with a specific variable name override.
+     * Default implementation delegates to the standard method, ignoring the variable name.
+     * Implementations can override this to use the provided variable name.
+     *
+     * @param code              The CodeBlock.Builder to add generated code to.
+     * @param type              The runtime Type being parsed.
+     * @param objVarName        The variable name of the parent JSONObjectHandle.
+     * @param parserPackage     The package for generated parsers.
+     * @param accessExpression  A CodeBlock representing how to access the raw JSON data.
+     * @param level             The current nesting level.
+     * @param fieldType         The exact generic type of the original field/setter parameter.
+     * @param variableName      The desired variable name for the parsed value, or null for default naming.
+     * @return The name of the variable declared within the generated code block.
+     */
+    default String generateParsingCodeInto(CodeBlock.Builder code, Type type, String objVarName, String parserPackage,
+        CodeBlock accessExpression, int level, Type fieldType, String variableName) {
+        // Default: ignore variableName and use standard method
+        return generateParsingCodeInto(code, type, objVarName, parserPackage, accessExpression, level, fieldType);
+    }
 } 

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/util/FileUtils.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/util/FileUtils.java
@@ -186,6 +186,46 @@ public final class FileUtils {
     return new File(cwd).getParentFile().getAbsolutePath() + "/src/main/java";
   }
 
+  /**
+   * Derives source root directories from the system classpath.
+   * For each classpath entry ending in /target/classes, checks if a corresponding
+   * /src/main/java directory exists.
+   *
+   * @return List of discovered source root directories
+   */
+  public static List<String> deriveSourceRootsFromClasspath() {
+    final String classpath = System.getProperty("java.class.path");
+    if (classpath == null || classpath.isEmpty()) {
+      return List.of();
+    }
+    return deriveSourceRootsFromClasspathEntries(List.of(classpath.split(File.pathSeparator)));
+  }
+
+  /**
+   * Derives source root directories from the given classpath entries.
+   * For each classpath entry ending in /target/classes, checks if a corresponding
+   * /src/main/java directory exists.
+   *
+   * @param classpathEntries List of classpath entries to scan
+   * @return List of discovered source root directories
+   */
+  public static List<String> deriveSourceRootsFromClasspathEntries(final List<String> classpathEntries) {
+    final List<String> sourceRoots = new java.util.ArrayList<>();
+
+    for (final String entry : classpathEntries) {
+      if (entry.endsWith("/target/classes") || entry.endsWith(File.separator + "target" + File.separator + "classes")) {
+        final String sourceRoot = entry
+            .replace("/target/classes", "/src/main/java")
+            .replace(File.separator + "target" + File.separator + "classes", File.separator + "src" + File.separator + "main" + File.separator + "java");
+        final File sourceDir = new File(sourceRoot);
+        if (sourceDir.isDirectory()) {
+          sourceRoots.add(sourceRoot);
+        }
+      }
+    }
+    return sourceRoots;
+  }
+
   public static String getSimpleClassName(final String fullyQualifiedClassName) {
     return fullyQualifiedClassName.substring(fullyQualifiedClassName.lastIndexOf('.') + 1);
   }

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/validator/ConfigurationValidator.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/validator/ConfigurationValidator.java
@@ -27,6 +27,7 @@ import com.palantir.javapoet.ClassName;
 
 import jsinterop.annotations.JsProperty;
 
+import nl.aerius.codegen.analyzer.ConstructorAnalyzer;
 import nl.aerius.codegen.analyzer.TypeAnalyzer;
 import nl.aerius.codegen.util.ClassFinder;
 import nl.aerius.codegen.util.FileUtils;
@@ -44,10 +45,12 @@ public class ConfigurationValidator {
   private final Set<String> customParserTypes = new HashSet<>();
   private final Set<String> skippedTypes = new HashSet<>();
   private final Set<Class<?>> validatedClasses = new HashSet<>();
+  private final Set<Class<?>> constructorBasedTypes = new HashSet<>();
   private final TypeAnalyzer typeAnalyzer;
   private final ClassFinder classFinder;
   private final Logger logger;
 
+  private ConstructorAnalyzer constructorAnalyzer;
   private boolean hasErrors = false;
 
   public ConfigurationValidator(final ClassFinder classFinder, final Logger logger) {
@@ -63,6 +66,16 @@ public class ConfigurationValidator {
     }
     // Also set custom parser types on the TypeAnalyzer instance
     this.typeAnalyzer.setCustomParserTypes(customParserTypes);
+  }
+
+  /**
+   * Sets the source roots for constructor analysis.
+   * Must be called before validation to enable constructor-based type detection.
+   *
+   * @param sourceRoots List of source root directories to search for source files
+   */
+  public void setSourceRoots(final List<String> sourceRoots) {
+    this.constructorAnalyzer = new ConstructorAnalyzer(sourceRoots, logger);
   }
 
   public void addSkippedType(final String fullyQualifiedClassName) {
@@ -249,8 +262,16 @@ public class ConfigurationValidator {
       return; // Still return as this is a fundamental issue
     }
 
-    // Check for public no-args constructor (Skip for interfaces)
-    if (!clazz.isInterface()) {
+    // Check if this class can use constructor-based parsing (immutable type)
+    final boolean isConstructorBasedType = !clazz.isInterface() && canUseConstructorBasedParsing(clazz);
+    if (isConstructorBasedType) {
+      constructorBasedTypes.add(clazz);
+      logger.info("\u2139\ufe0f  " + clazz.getName() + ": Using constructor-based parsing (immutable type)");
+    }
+
+    // Check for public no-args constructor (Skip for interfaces, abstract classes, and constructor-based types)
+    // Abstract classes can't be instantiated directly, so they don't need a public no-args constructor
+    if (!clazz.isInterface() && !Modifier.isAbstract(clazz.getModifiers()) && !isConstructorBasedType) {
       if (!validateConstructor(clazz, treatErrorsAsWarnings)) {
         classHasIssues = true;
       }
@@ -268,7 +289,7 @@ public class ConfigurationValidator {
       if (!validateField(clazz, field, treatErrorsAsWarnings)) {
         classHasIssues = true;
       }
-      if (!validateGetterSetter(clazz, field, treatErrorsAsWarnings)) {
+      if (!validateGetterSetter(clazz, field, treatErrorsAsWarnings, isConstructorBasedType)) {
         classHasIssues = true;
       }
       if (!validateFieldType(clazz, field, treatErrorsAsWarnings)) { // Pass class for context
@@ -346,6 +367,20 @@ public class ConfigurationValidator {
     }
   }
 
+  /**
+   * Checks if a class can use constructor-based parsing.
+   * A class can use constructor-based parsing if:
+   * 1. ConstructorAnalyzer is configured (source roots set)
+   * 2. The class has a constructor with parameters matching all parseable fields
+   * 3. The class does NOT have setters for all fields (i.e., it's immutable)
+   */
+  private boolean canUseConstructorBasedParsing(final Class<?> clazz) {
+    if (constructorAnalyzer == null) {
+      return false;
+    }
+    return constructorAnalyzer.canUseConstructorBasedParsing(clazz);
+  }
+
   private boolean validateField(final Class<?> clazz, final Field field, final boolean treatErrorsAsWarnings) {
     boolean isValid = true;
     if (!Modifier.isPrivate(field.getModifiers())) {
@@ -372,7 +407,8 @@ public class ConfigurationValidator {
     return isValid;
   }
 
-  private boolean validateGetterSetter(final Class<?> clazz, final Field field, final boolean treatErrorsAsWarnings) {
+  private boolean validateGetterSetter(final Class<?> clazz, final Field field, final boolean treatErrorsAsWarnings,
+      final boolean isConstructorBasedType) {
     final String fieldName = field.getName();
     final String capitalizedName = fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1);
     boolean isValid = true;
@@ -424,7 +460,12 @@ public class ConfigurationValidator {
       }
     }
 
-    // Always check setter
+    // Skip setter validation for constructor-based types (they use constructor parameters instead)
+    if (isConstructorBasedType) {
+      return isValid;
+    }
+
+    // Check setter for non-constructor-based types
     try {
       final Method setter = clazz.getMethod("set" + capitalizedName, field.getType());
       if (!Modifier.isPublic(setter.getModifiers())) {

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/validator/ConfigurationValidator.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/validator/ConfigurationValidator.java
@@ -269,9 +269,12 @@ public class ConfigurationValidator {
       logger.info("\u2139\ufe0f  " + clazz.getName() + ": Using constructor-based parsing (immutable type)");
     }
 
-    // Check for public no-args constructor (Skip for interfaces, abstract classes, and constructor-based types)
+    // Check if this class has any matching constructor (for validation purposes)
+    final boolean hasValidConstructor = !clazz.isInterface() && hasMatchingConstructor(clazz);
+
+    // Check for public no-args constructor (Skip for interfaces, abstract classes, and types with matching constructor)
     // Abstract classes can't be instantiated directly, so they don't need a public no-args constructor
-    if (!clazz.isInterface() && !Modifier.isAbstract(clazz.getModifiers()) && !isConstructorBasedType) {
+    if (!clazz.isInterface() && !Modifier.isAbstract(clazz.getModifiers()) && !hasValidConstructor) {
       if (!validateConstructor(clazz, treatErrorsAsWarnings)) {
         classHasIssues = true;
       }
@@ -379,6 +382,18 @@ public class ConfigurationValidator {
       return false;
     }
     return constructorAnalyzer.canUseConstructorBasedParsing(clazz);
+  }
+
+  /**
+   * Checks if a class has a constructor that could be used for initialization.
+   * Unlike canUseConstructorBasedParsing(), this does NOT require the class to be immutable.
+   * Used for validation to determine if a no-arg constructor is required.
+   */
+  private boolean hasMatchingConstructor(final Class<?> clazz) {
+    if (constructorAnalyzer == null) {
+      return false;
+    }
+    return constructorAnalyzer.hasMatchingConstructor(clazz);
   }
 
   private boolean validateField(final Class<?> clazz, final Field field, final boolean treatErrorsAsWarnings) {

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/validator/ConfigurationValidator.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/validator/ConfigurationValidator.java
@@ -451,7 +451,15 @@ public class ConfigurationValidator {
     try {
       // Check if this is a Map field
       if (Map.class.isAssignableFrom(field.getType())) {
-        final Type[] genericTypes = ((ParameterizedType) field.getGenericType()).getActualTypeArguments();
+        final Type genericType = field.getGenericType();
+
+        // If the field type is not parameterized directly (e.g., MyMap extends HashMap<K,V>),
+        // skip the map key validation as we can't determine the key type from the field
+        if (!(genericType instanceof ParameterizedType)) {
+          return fieldTypeIsValid;
+        }
+
+        final Type[] genericTypes = ((ParameterizedType) genericType).getActualTypeArguments();
         final Type keyType = genericTypes[0];
 
         // Skip primitive types, their wrappers, String, and enums as they don't need

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/ParserGeneratorTestBase.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/ParserGeneratorTestBase.java
@@ -45,9 +45,14 @@ public abstract class ParserGeneratorTestBase {
 
     System.out.println("Creating output directory: " + outputDir.toAbsolutePath());
     Files.createDirectories(outputDir);
-    System.out.println("=== Test Base @BeforeAll Complete ===");
 
     ParserWriterUtils.initParsers(CLASSFINDER, LOGGER);
+
+    // Set up source roots for constructor analysis
+    final List<String> sourceRoots = List.of("src/test/java", "src/main/java");
+    ParserWriterUtils.setSourceRoots(sourceRoots, LOGGER);
+
+    System.out.println("=== Test Base @BeforeAll Complete ===");
   }
 
   // Helper method remains static

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/ParserGeneratorTestBase.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/ParserGeneratorTestBase.java
@@ -6,6 +6,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
@@ -15,6 +17,7 @@ import nl.aerius.codegen.ParserGenerator;
 import nl.aerius.codegen.generator.ParserWriterUtils;
 import nl.aerius.codegen.util.ClassFinder;
 import nl.aerius.codegen.util.Logger;
+import nl.aerius.codegen.validator.ConfigurationValidator;
 
 // Removed TestInstance - let subclasses handle lifecycle
 public abstract class ParserGeneratorTestBase {
@@ -23,6 +26,7 @@ public abstract class ParserGeneratorTestBase {
 
   private static final ClassFinder CLASSFINDER = new ClassFinder() {};
   private static final Logger LOGGER = new Logger() {};
+  private static final List<String> SOURCE_ROOTS = List.of("src/test/java", "src/main/java");
 
   // Make paths static as they are initialized once
   protected static Path outputDir;
@@ -49,8 +53,7 @@ public abstract class ParserGeneratorTestBase {
     ParserWriterUtils.initParsers(CLASSFINDER, LOGGER);
 
     // Set up source roots for constructor analysis
-    final List<String> sourceRoots = List.of("src/test/java", "src/main/java");
-    ParserWriterUtils.setSourceRoots(sourceRoots, LOGGER);
+    ParserWriterUtils.setSourceRoots(SOURCE_ROOTS, LOGGER);
 
     System.out.println("=== Test Base @BeforeAll Complete ===");
   }
@@ -81,6 +84,8 @@ public abstract class ParserGeneratorTestBase {
   protected void generateParser(final Class<?> rootClass) throws IOException {
     if (outputDir == null)
       throw new IllegalStateException("outputDir not initialized. Ensure setUpDirectories() ran.");
+    // Validate before generating
+    validateClass(rootClass, null);
     // Call the most specific method, providing fixed generator name and details for testing
     ParserGenerator.generateParsersForClass(rootClass, TEST_PACKAGE, outputDir.toString(), null /* customParserDir */,
         "nl.aerius.codegen.ParserGenerator", CLASSFINDER, LOGGER);
@@ -89,9 +94,38 @@ public abstract class ParserGeneratorTestBase {
   protected void generateParser(final Class<?> rootClass, final String customParserDir) throws IOException {
     if (outputDir == null)
       throw new IllegalStateException("outputDir not initialized. Ensure setUpDirectories() ran.");
+    // Validate before generating
+    validateClass(rootClass, customParserDir);
     // Call the most specific method, providing fixed generator name and details for testing
     ParserGenerator.generateParsersForClass(rootClass, TEST_PACKAGE, outputDir.toString(), customParserDir, "nl.aerius.codegen.ParserGenerator",
         CLASSFINDER, LOGGER);
+  }
+
+  /**
+   * Validates a class before parser generation.
+   * This ensures tests don't bypass validation that would run in production.
+   */
+  private void validateClass(final Class<?> rootClass, final String customParserDir) {
+    final ConfigurationValidator validator = new ConfigurationValidator(CLASSFINDER, LOGGER);
+    validator.setSourceRoots(SOURCE_ROOTS);
+    if (customParserDir != null && !customParserDir.isEmpty()) {
+      // Find and register custom parsers if directory is provided
+      try (Stream<Path> files = Files.list(Path.of(customParserDir))) {
+        final Set<String> customParserTypes = files
+            .filter(path -> path.toString().endsWith("Parser.java"))
+            .map(path -> {
+              final String fileName = path.getFileName().toString();
+              return fileName.substring(0, fileName.length() - 11); // Remove "Parser.java"
+            })
+            .collect(Collectors.toSet());
+        validator.setCustomParserTypes(customParserTypes);
+      } catch (final IOException e) {
+        // Ignore - custom parser discovery is optional
+      }
+    }
+    if (!validator.validate(rootClass)) {
+      throw new IllegalStateException(rootClass.getName() + " validation failed. Please fix the issues before generating parsers.");
+    }
   }
 
   // This method modifies files, so fine as non-static if called after generation

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestConstructorBasedType.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestConstructorBasedType.java
@@ -1,0 +1,46 @@
+package nl.aerius.codegen.test.types;
+
+/**
+ * Test class for constructor-based parsing.
+ * This class has no setters - all field values must be provided via the constructor.
+ * The parser generator should detect this and generate a constructor-based parser.
+ */
+public class TestConstructorBasedType {
+  private final String name;
+  private final int value;
+  private final Double optionalValue;
+
+  public TestConstructorBasedType(String name, int value, Double optionalValue) {
+    this.name = name;
+    this.value = value;
+    this.optionalValue = optionalValue;
+  }
+
+  // Getters only, NO setters
+  public String getName() {
+    return name;
+  }
+
+  public int getValue() {
+    return value;
+  }
+
+  public Double getOptionalValue() {
+    return optionalValue;
+  }
+
+  /**
+   * Creates a fully populated instance with test values.
+   */
+  public static TestConstructorBasedType createFullObject() {
+    return new TestConstructorBasedType("test", 42, 3.14);
+  }
+
+  /**
+   * Creates an instance with null values where possible.
+   * Primitive types will have their default values.
+   */
+  public static TestConstructorBasedType createNullObject() {
+    return new TestConstructorBasedType(null, 0, null);
+  }
+}

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestRootObjectType.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestRootObjectType.java
@@ -22,6 +22,7 @@ public class TestRootObjectType {
 
   private TestPolyBase testPolyBase;
   private TestPrimitiveArrayType primitiveArrays;
+  private TestConstructorBasedType constructorBased;
 
   public String getFoo() {
     return foo;
@@ -135,6 +136,14 @@ public class TestRootObjectType {
     this.primitiveArrays = primitiveArrays;
   }
 
+  public TestConstructorBasedType getConstructorBased() {
+    return constructorBased;
+  }
+
+  public void setConstructorBased(TestConstructorBasedType constructorBased) {
+    this.constructorBased = constructorBased;
+  }
+
   public static TestRootObjectType createFullObject() {
     TestRootObjectType obj = new TestRootObjectType();
     obj.setFoo("test string");
@@ -151,6 +160,7 @@ public class TestRootObjectType {
     obj.setNestedMapType(TestNestedMapType.createFullObject());
     obj.setTestPolyBase(new TestPolySubA("BaseValueA", 123));
     obj.setPrimitiveArrays(TestPrimitiveArrayType.createFullObject());
+    obj.setConstructorBased(TestConstructorBasedType.createFullObject());
     return obj;
   }
 

--- a/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestConstructorBasedTypeParser.java
+++ b/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestConstructorBasedTypeParser.java
@@ -1,0 +1,53 @@
+package nl.aerius.codegen.test.generated;
+
+import javax.annotation.processing.Generated;
+
+import nl.aerius.codegen.test.types.TestConstructorBasedType;
+import nl.aerius.json.JSONObjectHandle;
+
+@Generated(value = "nl.aerius.codegen.ParserGenerator", date = "2024-01-01T00:00:00")
+public class TestConstructorBasedTypeParser {
+  public static TestConstructorBasedType parse(final String jsonText) {
+    if (jsonText == null) {
+      return null;
+    }
+
+    return parse(JSONObjectHandle.fromText(jsonText));
+  }
+
+  public static TestConstructorBasedType parse(final JSONObjectHandle baseObj) {
+    if (baseObj == null) {
+      return null;
+    }
+
+    // Parse name
+    if (!baseObj.has("name")) {
+      throw new RuntimeException("Required field 'name' is missing");
+    }
+    final String name;
+    if (!baseObj.isNull("name")) {
+      name = baseObj.getString("name");
+    } else {
+      name = null;
+    }
+
+    // Parse value
+    if (!baseObj.has("value")) {
+      throw new RuntimeException("Required field 'value' is missing");
+    }
+    final int value = baseObj.getInteger("value");
+
+    // Parse optionalValue
+    if (!baseObj.has("optionalValue")) {
+      throw new RuntimeException("Required field 'optionalValue' is missing");
+    }
+    final Double optionalValue;
+    if (!baseObj.isNull("optionalValue")) {
+      optionalValue = baseObj.getNumber("optionalValue");
+    } else {
+      optionalValue = null;
+    }
+
+    return new TestConstructorBasedType(name, value, optionalValue);
+  }
+}

--- a/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestConstructorBasedTypeParser.java
+++ b/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestConstructorBasedTypeParser.java
@@ -24,12 +24,7 @@ public class TestConstructorBasedTypeParser {
     if (!baseObj.has("name")) {
       throw new RuntimeException("Required field 'name' is missing");
     }
-    final String name;
-    if (!baseObj.isNull("name")) {
-      name = baseObj.getString("name");
-    } else {
-      name = null;
-    }
+    final String name = baseObj.getString("name");
 
     // Parse value
     if (!baseObj.has("value")) {
@@ -41,12 +36,7 @@ public class TestConstructorBasedTypeParser {
     if (!baseObj.has("optionalValue")) {
       throw new RuntimeException("Required field 'optionalValue' is missing");
     }
-    final Double optionalValue;
-    if (!baseObj.isNull("optionalValue")) {
-      optionalValue = baseObj.getNumber("optionalValue");
-    } else {
-      optionalValue = null;
-    }
+    final Double optionalValue = baseObj.getNumber("optionalValue");
 
     return new TestConstructorBasedType(name, value, optionalValue);
   }

--- a/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestRootObjectTypeParser.java
+++ b/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestRootObjectTypeParser.java
@@ -6,6 +6,7 @@ import nl.aerius.codegen.test.custom.TestCustomParserTypeParser;
 import nl.aerius.codegen.test.types.ConcreteType;
 import nl.aerius.codegen.test.types.TestAdvancedMapType;
 import nl.aerius.codegen.test.types.TestComplexCollectionType;
+import nl.aerius.codegen.test.types.TestConstructorBasedType;
 import nl.aerius.codegen.test.types.TestCustomParserType;
 import nl.aerius.codegen.test.types.TestEnumListType;
 import nl.aerius.codegen.test.types.TestEnumType;
@@ -124,6 +125,12 @@ public class TestRootObjectTypeParser {
     if (baseObj.has("primitiveArrays") && !baseObj.isNull("primitiveArrays")) {
       final TestPrimitiveArrayType value = TestPrimitiveArrayTypeParser.parse(baseObj.getObject("primitiveArrays"));
       config.setPrimitiveArrays(value);
+    }
+
+    // Parse constructorBased
+    if (baseObj.has("constructorBased") && !baseObj.isNull("constructorBased")) {
+      final TestConstructorBasedType value = TestConstructorBasedTypeParser.parse(baseObj.getObject("constructorBased"));
+      config.setConstructorBased(value);
     }
   }
 }

--- a/gwt-beans-codegen-maven-plugin/src/main/java/nl/aerius/codegen/plugin/ParserGeneratorMojo.java
+++ b/gwt-beans-codegen-maven-plugin/src/main/java/nl/aerius/codegen/plugin/ParserGeneratorMojo.java
@@ -71,6 +71,13 @@ public class ParserGeneratorMojo extends AbstractMojo {
   @Parameter
   private String customParserDir;
 
+  /**
+   * Extra source roots to search for Java source files.
+   * Useful for multi-module projects where domain classes are in separate modules.
+   * Paths can be absolute or relative to the project base directory.
+   */
+  @Parameter
+  private List<String> extraSourceRoots;
 
   /**
    * The Maven project instance for the executing project.
@@ -97,7 +104,22 @@ public class ParserGeneratorMojo extends AbstractMojo {
       ParserWriterUtils.initParsers(finder, logger);
 
       // Derive source roots from Maven project classpath
-      final List<String> sourceRoots = FileUtils.deriveSourceRootsFromClasspathEntries(project.getRuntimeClasspathElements());
+      final List<String> sourceRoots = new ArrayList<>(
+          FileUtils.deriveSourceRootsFromClasspathEntries(project.getRuntimeClasspathElements()));
+
+      // Add extra source roots if configured
+      if (extraSourceRoots != null && !extraSourceRoots.isEmpty()) {
+        for (final String extraRoot : extraSourceRoots) {
+          final String absoluteRoot = resolvePathAgainstProjectBase(extraRoot);
+          if (new File(absoluteRoot).isDirectory()) {
+            sourceRoots.add(absoluteRoot);
+            getLog().info("Added extra source root: " + absoluteRoot);
+          } else {
+            getLog().warn("Extra source root does not exist or is not a directory: " + absoluteRoot);
+          }
+        }
+      }
+
       getLog().info("Source roots: " + sourceRoots);
 
       for (final String rootClassName : rootClassNames) {
@@ -121,6 +143,14 @@ public class ParserGeneratorMojo extends AbstractMojo {
     } else {
       return Paths.get(absoluteJavaSourceDir, path).toFile().getAbsolutePath();
     }
+  }
+
+  private String resolvePathAgainstProjectBase(final String path) {
+    final File file = new File(path);
+    if (file.isAbsolute()) {
+      return file.getAbsolutePath();
+    }
+    return new File(project.getBasedir(), path).getAbsolutePath();
   }
 
   private void addGeneratedSourcesAsResource(final String outputPath, final String absoluteJavaSourceDir) {

--- a/gwt-beans-codegen-maven-plugin/src/main/java/nl/aerius/codegen/plugin/ParserGeneratorMojo.java
+++ b/gwt-beans-codegen-maven-plugin/src/main/java/nl/aerius/codegen/plugin/ParserGeneratorMojo.java
@@ -41,6 +41,7 @@ import org.apache.maven.project.MavenProject;
 import nl.aerius.codegen.ParserGenerator;
 import nl.aerius.codegen.generator.ParserWriterUtils;
 import nl.aerius.codegen.util.ClassFinder;
+import nl.aerius.codegen.util.FileUtils;
 import nl.aerius.codegen.util.Logger;
 
 @Mojo(name = "generate-parsers", defaultPhase = LifecyclePhase.GENERATE_SOURCES, requiresDependencyResolution = ResolutionScope.COMPILE)
@@ -94,9 +95,14 @@ public class ParserGeneratorMojo extends AbstractMojo {
 
     try (final MoJoClassFinder finder = new MoJoClassFinder()) {
       ParserWriterUtils.initParsers(finder, logger);
+
+      // Derive source roots from Maven project classpath
+      final List<String> sourceRoots = FileUtils.deriveSourceRootsFromClasspathEntries(project.getRuntimeClasspathElements());
+      getLog().info("Source roots: " + sourceRoots);
+
       for (final String rootClassName : rootClassNames) {
         ParserGenerator.generateParsers(rootClassName, absoluteOutputDir, parserPackage,
-            customParserDirectory, finder, logger);
+            customParserDirectory, sourceRoots, finder, logger);
       }
     } catch (ClassNotFoundException | IOException | DependencyResolutionRequiredException |  IllegalArgumentException | SecurityException e) {
       throw new MojoExecutionException(e);


### PR DESCRIPTION
One major limitation of the generator project is it requires setters even for POJOs that are supposed to be immutable. An acceptable compromise was to make setters deprecated or otherwise flag them, however the superior solution is to use the constructor and create immutable objects properly. This addition checks if that is possible, and if it is instantiate the object via the constructor.

The way it works, is it matches fields to parameters in the constructor. It'll match only the constructor which matches ALL fields. Order does not matter.

If constructor matching does not work, it'll fall back to calling setters.

Remaining limitations:
- if there are parent classes with fields, SOL (might try to support in the future)
- constructors which perform some kind of logic on its parameters before assigning to fields, SOL (will never support)

Because constructor parameters are obfuscated, the validator gizmo needs to be able to look at sources, so there is a source path derivation logic (and config option) that can be passed. In practice the derivation will just work.

---

Before:
```
  final MyKey config = new MyKey();
  config.setCode(baseObj.getString("code"));
  config.setSubstance(Substance.valueOf(baseObj.getString("substance")));
  return config;
```

  After:
```
  final String code = baseObj.getString("code");
  final int value = baseObj.getInteger("value");

  return new MyKey(code, value);
```