### PR TITLE
Constructor parser upgrades

### DIFF
--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/analyzer/ConstructorAnalyzer.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/analyzer/ConstructorAnalyzer.java
@@ -12,11 +12,13 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
 
+import nl.aerius.codegen.generator.parser.ParserCommonUtils;
 import nl.aerius.codegen.util.Logger;
 
 /**
@@ -231,18 +233,25 @@ public class ConstructorAnalyzer {
   }
 
   /**
-   * Gets all fields that should be parsed (non-static, non-transient, non-synthetic).
+   * Canonical predicate for fields that participate in JSON parsing: non-static,
+   * non-transient, non-synthetic, and not {@code @JsonIgnore}. Shared by analyzer,
+   * validator, and generator.
    */
   public static List<Field> getParseableFields(final Class<?> clazz) {
     final List<Field> fields = new ArrayList<>();
     for (final Field field : clazz.getDeclaredFields()) {
-      if (!Modifier.isStatic(field.getModifiers())
-          && !Modifier.isTransient(field.getModifiers())
-          && !field.isSynthetic()) {
+      if (isParseable(field)) {
         fields.add(field);
       }
     }
     return fields;
+  }
+
+  public static boolean isParseable(final Field field) {
+    return !Modifier.isStatic(field.getModifiers())
+        && !Modifier.isTransient(field.getModifiers())
+        && !field.isSynthetic()
+        && !field.isAnnotationPresent(JsonIgnore.class);
   }
 
   /**
@@ -301,11 +310,13 @@ public class ConstructorAnalyzer {
   }
 
   /**
-   * Checks if a source type name matches a reflection type.
+   * Matches a source type name (with generics stripped) against a reflection type, so
+   * {@code List<String>} resolves to raw {@code List} / {@code java.util.List}.
    */
   private boolean typeNamesMatch(final String sourceTypeName, final Class<?> reflectionType) {
-    return sourceTypeName.equals(reflectionType.getName())
-        || sourceTypeName.equals(reflectionType.getSimpleName());
+    final String rawSourceName = ParserCommonUtils.stripGenerics(sourceTypeName);
+    return rawSourceName.equals(reflectionType.getName())
+        || rawSourceName.equals(reflectionType.getSimpleName());
   }
 
   /**

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/analyzer/ConstructorAnalyzer.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/analyzer/ConstructorAnalyzer.java
@@ -3,6 +3,7 @@ package nl.aerius.codegen.analyzer;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.RecordComponent;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -93,6 +94,12 @@ public class ConstructorAnalyzer {
       return Optional.empty();
     }
 
+    // Records: use the compiler-generated canonical constructor and component names
+    // directly via reflection. No source-file lookup needed.
+    if (clazz.isRecord()) {
+      return buildRecordConstructorInfo(clazz, parseableFields);
+    }
+
     final Set<String> fieldNames = parseableFields.stream()
         .map(Field::getName)
         .collect(Collectors.toSet());
@@ -159,6 +166,25 @@ public class ConstructorAnalyzer {
     }
 
     return Optional.empty();
+  }
+
+  private Optional<ConstructorInfo> buildRecordConstructorInfo(final Class<?> clazz, final List<Field> parseableFields) {
+    final RecordComponent[] components = clazz.getRecordComponents();
+    final List<String> paramNames = Arrays.stream(components)
+        .map(RecordComponent::getName)
+        .collect(Collectors.toList());
+    final Class<?>[] paramTypes = Arrays.stream(components)
+        .map(RecordComponent::getType)
+        .toArray(Class<?>[]::new);
+    try {
+      final Constructor<?> canonical = clazz.getDeclaredConstructor(paramTypes);
+      logger.info("Found canonical record constructor for " + clazz.getName() + " with parameters: " + paramNames);
+      return Optional.of(new ConstructorInfo(canonical, paramNames, parseableFields));
+    } catch (final NoSuchMethodException e) {
+      // Should be impossible: every record has a compiler-generated canonical constructor.
+      logger.warn("Record " + clazz.getName() + " has no canonical constructor: " + e.getMessage());
+      return Optional.empty();
+    }
   }
 
   /**

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/analyzer/TypeAnalyzer.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/analyzer/TypeAnalyzer.java
@@ -1,7 +1,6 @@
 package nl.aerius.codegen.analyzer;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
@@ -160,13 +159,11 @@ public class TypeAnalyzer {
 
     // Always analyze fields, even for types with custom parsers
     // This ensures we discover all types that might need parsers
-    for (final Field field : type.getDeclaredFields()) {
-      if (!Modifier.isStatic(field.getModifiers()) && !Modifier.isTransient(field.getModifiers())) {
-        try {
-          analyzeField(field);
-        } catch (final TypeNotPresentException e) {
-          skippedTypes.add(e.typeName());
-        }
+    for (final Field field : ConstructorAnalyzer.getParseableFields(type)) {
+      try {
+        analyzeField(field);
+      } catch (final TypeNotPresentException e) {
+        skippedTypes.add(e.typeName());
       }
     }
   }

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriterUtils.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriterUtils.java
@@ -133,10 +133,10 @@ public final class ParserWriterUtils {
 
     if (constructorInfo.isPresent()) {
       // Constructor-based: single parse method that constructs the object
-      typeSpec.addMethod(createConstructorBasedParseMethod(targetClass, parserPackage, classFinder, constructorInfo.get()));
+      typeSpec.addMethod(createConstructorBasedParseMethod(targetClass, parserPackage, constructorInfo.get()));
     } else {
       // Setter-based: existing approach
-      addSetterBasedParseMethods(typeSpec, targetClass, parserPackage, classFinder);
+      addSetterBasedParseMethods(typeSpec, targetClass, parserPackage);
     }
   }
 
@@ -144,13 +144,13 @@ public final class ParserWriterUtils {
    * Adds setter-based parse methods to the type specification.
    */
   private static void addSetterBasedParseMethods(final TypeSpec.Builder typeSpec, final Class<?> targetClass,
-      final String parserPackage, final ClassFinder classFinder) {
+      final String parserPackage) {
     if (hasJsonTypeInfoWithNameDiscriminator(targetClass)) {
       typeSpec.addMethod(createPolymorphicObjectParseMethod(targetClass, parserPackage));
     } else {
       typeSpec.addMethod(createStandardObjectParseMethod(targetClass, parserPackage));
     }
-    typeSpec.addMethod(createConfigParseMethod(targetClass, parserPackage, classFinder));
+    typeSpec.addMethod(createConfigParseMethod(targetClass, parserPackage));
   }
 
   /**
@@ -248,16 +248,11 @@ public final class ParserWriterUtils {
       }
     }
     // Fallback for complex types - might need refinement
-    String typeName = type.getTypeName();
-    // Basic attempt to get a simple name
-    if (typeName.contains("<")) {
-      typeName = typeName.substring(0, typeName.indexOf('<'));
-    }
+    String typeName = ParserCommonUtils.stripGenerics(type.getTypeName());
     if (typeName.contains(".")) {
       typeName = typeName.substring(typeName.lastIndexOf('.') + 1);
     }
     return determineParserClassName(typeName, parserPackage);
-    // throw new IllegalArgumentException("Cannot determine parser class name for type: " + type.getTypeName());
   }
 
   /**
@@ -376,7 +371,7 @@ public final class ParserWriterUtils {
    * Parses all fields into local variables and then calls the constructor.
    */
   private static MethodSpec createConstructorBasedParseMethod(final Class<?> targetClass, final String parserPackage,
-      final ClassFinder classFinder, final ConstructorInfo constructorInfo) {
+      final ConstructorInfo constructorInfo) {
     final ClassName targetClassName = ClassName.get(targetClass);
     final MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder("parse")
         .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
@@ -439,7 +434,7 @@ public final class ParserWriterUtils {
     return resultVar;
   }
 
-  private static MethodSpec createConfigParseMethod(final Class<?> targetClass, final String parserPackage, final ClassFinder classFinder) {
+  private static MethodSpec createConfigParseMethod(final Class<?> targetClass, final String parserPackage) {
     final ClassName targetClassName = ClassName.get(targetClass);
     final MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder("parse")
         .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
@@ -458,56 +453,30 @@ public final class ParserWriterUtils {
           .addStatement("$T.parse($L, config)", determineParserClassName(superclass, parserPackage), ParserCommonUtils.BASE_OBJECT_PARAM_NAME);
     }
 
-    // Process all fields
-    for (final Field field : targetClass.getDeclaredFields()) {
-      if (!java.lang.reflect.Modifier.isStatic(field.getModifiers())
-          && !java.lang.reflect.Modifier.isTransient(field.getModifiers())
-          && !field.isSynthetic()) {
+    for (final Field field : ConstructorAnalyzer.getParseableFields(targetClass)) {
+      methodBuilder.addCode("\n");
+      methodBuilder.addComment("Parse $L", field.getName());
+      final boolean requireNonNull = !ParserCommonUtils.isPrimitiveType(field.getGenericType());
+      methodBuilder.addCode(ParserCommonUtils.createFieldExistsCheck(
+          ParserCommonUtils.BASE_OBJECT_PARAM_NAME,
+          field.getName(),
+          requireNonNull,
+          innerCode -> {
+            final CodeBlock fieldAccess = ParserCommonUtils.createFieldAccessCode(
+                field.getGenericType(),
+                ParserCommonUtils.BASE_OBJECT_PARAM_NAME,
+                CodeBlock.of("$S", field.getName()));
 
-        // ==> INSERT @JsonIgnore CHECK HERE <==
-        try {
-          final Class<? extends java.lang.annotation.Annotation> jsonIgnoreAnnotation = (Class<? extends java.lang.annotation.Annotation>) classFinder
-              .forName("com.fasterxml.jackson.annotation.JsonIgnore");
-          if (field.isAnnotationPresent(jsonIgnoreAnnotation)) {
-            methodBuilder.addCode("\n"); // Add newline for spacing
-            methodBuilder.addComment("Skipping ignored field: $L", field.getName());
-            continue; // Skip processing this ignored field
-          }
-        } catch (final ClassNotFoundException e) {
-          // Log or handle the case where JsonIgnore annotation class is not available on the classpath during generation
-          methodBuilder.addCode("\n");
-          methodBuilder.addComment("WARNING: Cannot check for @JsonIgnore, com.fasterxml.jackson.annotation.JsonIgnore not found.");
-          // Proceed without checking - might generate code for ignored fields if annotation is used but class not found
-        }
-        // ==> END @JsonIgnore CHECK <==
-
-        methodBuilder.addCode("\n");
-        methodBuilder.addComment("Parse $L", field.getName());
-        // Determine if null check is required (true for non-primitives)
-        final boolean requireNonNull = !ParserCommonUtils.isPrimitiveType(field.getGenericType());
-        methodBuilder.addCode(ParserCommonUtils.createFieldExistsCheck(
-            ParserCommonUtils.BASE_OBJECT_PARAM_NAME, // Use constant here
-            field.getName(),
-            requireNonNull, // Pass determined value
-            innerCode -> {
-              // Pass CodeBlock representing the field name string literal
-              final CodeBlock fieldAccess = ParserCommonUtils.createFieldAccessCode(
-                  field.getGenericType(),
-                  ParserCommonUtils.BASE_OBJECT_PARAM_NAME, // Use constant here
-                  CodeBlock.of("$S", field.getName()));
-
-              final String resultVar = dispatchGenerateParsingCodeInto(
-                  innerCode,
-                  field.getGenericType(),
-                  ParserCommonUtils.BASE_OBJECT_PARAM_NAME, // Use constant here
-                  parserPackage,
-                  fieldAccess, // Pass the code to access the field's data
-                  1, // Start top-level fields at level 1 - Remove last arg
-                  field.getGenericType() // Pass fieldType
-              );
-              innerCode.addStatement("config.set$L($L)", ParserCommonUtils.capitalize(field.getName()), resultVar);
-            }));
-      }
+            final String resultVar = dispatchGenerateParsingCodeInto(
+                innerCode,
+                field.getGenericType(),
+                ParserCommonUtils.BASE_OBJECT_PARAM_NAME,
+                parserPackage,
+                fieldAccess,
+                1,
+                field.getGenericType());
+            innerCode.addStatement("config.set$L($L)", ParserCommonUtils.capitalize(field.getName()), resultVar);
+          }));
     }
 
     return methodBuilder.build();

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/CollectionFieldParser.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/CollectionFieldParser.java
@@ -68,25 +68,32 @@ public class CollectionFieldParser implements TypeParser {
   public String generateParsingCodeInto(final CodeBlock.Builder code, final Type type, final String objVarName, final String parserPackage,
       final CodeBlock accessExpression,
       final int level) {
-    return generateParsingCodeInto(code, type, objVarName, parserPackage, accessExpression, level, type);
+    return generateParsingCodeInto(code, type, objVarName, parserPackage, accessExpression, level, type, null);
   }
 
   @Override
   public String generateParsingCodeInto(final CodeBlock.Builder code, final Type type, final String objVarName, final String parserPackage,
       final CodeBlock accessExpression,
       final int level, final Type fieldType) {
+    return generateParsingCodeInto(code, type, objVarName, parserPackage, accessExpression, level, fieldType, null);
+  }
+
+  @Override
+  public String generateParsingCodeInto(final CodeBlock.Builder code, final Type type, final String objVarName, final String parserPackage,
+      final CodeBlock accessExpression,
+      final int level, final Type fieldType, final String variableName) {
     if (!canHandle(type)) {
       throw new IllegalArgumentException("CollectionFieldParser cannot handle type: " + type.getTypeName());
     }
 
     // Determine if it's a Collection<E> or an Object E[]
     if (type instanceof ParameterizedType && Collection.class.isAssignableFrom((Class<?>) ((ParameterizedType) type).getRawType())) {
-      return generateCollectionParsingCodeInto(code, (ParameterizedType) type, parserPackage, accessExpression, level, fieldType);
+      return generateCollectionParsingCodeInto(code, (ParameterizedType) type, parserPackage, accessExpression, level, fieldType, variableName);
     } else if (type instanceof Class<?> && ((Class<?>) type).isArray()) {
-      return generateObjectArrayParsingCodeInto(code, (Class<?>) type, parserPackage, accessExpression, level, fieldType);
+      return generateObjectArrayParsingCodeInto(code, (Class<?>) type, parserPackage, accessExpression, level, fieldType, variableName);
     } else if (type instanceof java.lang.reflect.GenericArrayType) {
       return generateGenericArrayParsingCodeInto(code, (java.lang.reflect.GenericArrayType) type, parserPackage, accessExpression, level,
-          fieldType);
+          fieldType, variableName);
     } else {
       throw new IllegalArgumentException("Unhandled type in CollectionFieldParser: " + type.getTypeName());
     }
@@ -95,7 +102,7 @@ public class CollectionFieldParser implements TypeParser {
   // Handles Collection<E>
   private String generateCollectionParsingCodeInto(final CodeBlock.Builder code, final ParameterizedType collectionRuntimeType,
       final String parserPackage,
-      final CodeBlock accessExpression, final int level, final Type fieldType) {
+      final CodeBlock accessExpression, final int level, final Type fieldType, final String variableName) {
     final Type elementType = collectionRuntimeType.getActualTypeArguments()[0];
     // Use fieldType to determine the variable declaration type
     final Type variableDeclarationType = fieldType;
@@ -104,14 +111,14 @@ public class CollectionFieldParser implements TypeParser {
 
     // Determine implementation and set resultVarName prefix
     if (variableDeclarationType instanceof Class<?> && Set.class.isAssignableFrom((Class<?>) variableDeclarationType)) {
-      resultVarName = ParserCommonUtils.getVariableNameForLevel(level, "Set");
+      resultVarName = variableName != null ? variableName : ParserCommonUtils.getVariableNameForLevel(level, "Set");
       collectionImpl = HASH_SET;
     } else if (variableDeclarationType instanceof ParameterizedType
         && Set.class.isAssignableFrom((Class<?>) ((ParameterizedType) variableDeclarationType).getRawType())) {
-      resultVarName = ParserCommonUtils.getVariableNameForLevel(level, "Set");
+      resultVarName = variableName != null ? variableName : ParserCommonUtils.getVariableNameForLevel(level, "Set");
       collectionImpl = HASH_SET;
     } else { // Default to List/ArrayList
-      resultVarName = ParserCommonUtils.getVariableNameForLevel(level, "List");
+      resultVarName = variableName != null ? variableName : ParserCommonUtils.getVariableNameForLevel(level, "List");
       collectionImpl = ARRAY_LIST;
     }
 
@@ -122,8 +129,9 @@ public class CollectionFieldParser implements TypeParser {
       return resultVarName;
     }
 
-    final String arrayVar = ParserCommonUtils.getVariableNameForLevel(level, "Array");
-    final String itemVar = ParserCommonUtils.getVariableNameForLevel(level, "Item");
+    // Prefix siblings with the field name (constructor path) or fall back to level-based names.
+    final String arrayVar = variableName != null ? variableName + "Array" : ParserCommonUtils.getVariableNameForLevel(level, "Array");
+    final String itemVar = variableName != null ? variableName + "Item" : ParserCommonUtils.getVariableNameForLevel(level, "Item");
 
     // 1. Get JSON Array
     code.addStatement("final $T $L = $L", ParserCommonUtils.getJSONArrayHandle(), arrayVar, accessExpression);
@@ -177,13 +185,13 @@ public class CollectionFieldParser implements TypeParser {
 
   // Handles Object E[] (e.g., String[], CustomObject[])
   private String generateObjectArrayParsingCodeInto(final CodeBlock.Builder code, final Class<?> arrayRuntimeType, final String parserPackage,
-      final CodeBlock accessExpression, final int level, final Type fieldType) {
+      final CodeBlock accessExpression, final int level, final Type fieldType, final String variableName) {
     final Type componentType = arrayRuntimeType.getComponentType();
-    // Use helper for variable names
-    final String resultVarName = ParserCommonUtils.getVariableNameForLevel(level, "Array");
-    final String arrayJsonVar = ParserCommonUtils.getVariableNameForLevel(level, "JsonArray");
-    final String itemVar = ParserCommonUtils.getVariableNameForLevel(level, "Item");
-    final String indexVar = ParserCommonUtils.getVariableNameForLevel(level, "Index");
+    // Prefix siblings with the field name (constructor path) or fall back to level-based names.
+    final String resultVarName = variableName != null ? variableName : ParserCommonUtils.getVariableNameForLevel(level, "Array");
+    final String arrayJsonVar = variableName != null ? variableName + "JsonArray" : ParserCommonUtils.getVariableNameForLevel(level, "JsonArray");
+    final String itemVar = variableName != null ? variableName + "Item" : ParserCommonUtils.getVariableNameForLevel(level, "Item");
+    final String indexVar = variableName != null ? variableName + "Index" : ParserCommonUtils.getVariableNameForLevel(level, "Index");
 
     // 1. Get the JSON Array - Use $T for ClassName
     code.addStatement("final $T $L = $L", ParserCommonUtils.getJSONArrayHandle(), arrayJsonVar, accessExpression);
@@ -218,13 +226,12 @@ public class CollectionFieldParser implements TypeParser {
 
   // Handles GenericArrayType (e.g., T[]) - Experimental
   private String generateGenericArrayParsingCodeInto(final CodeBlock.Builder code, final java.lang.reflect.GenericArrayType arrayRuntimeType,
-      final String parserPackage, final CodeBlock accessExpression, final int level, final Type fieldType) {
+      final String parserPackage, final CodeBlock accessExpression, final int level, final Type fieldType, final String variableName) {
     final Type componentType = arrayRuntimeType.getGenericComponentType();
-    // Use helper for variable names
-    final String resultVarName = ParserCommonUtils.getVariableNameForLevel(level, "Array");
-    final String arrayJsonVar = ParserCommonUtils.getVariableNameForLevel(level, "JsonArray");
-    final String itemVar = ParserCommonUtils.getVariableNameForLevel(level, "Item");
-    final String tempListVar = ParserCommonUtils.getVariableNameForLevel(level, "TempList");
+    final String resultVarName = variableName != null ? variableName : ParserCommonUtils.getVariableNameForLevel(level, "Array");
+    final String arrayJsonVar = variableName != null ? variableName + "JsonArray" : ParserCommonUtils.getVariableNameForLevel(level, "JsonArray");
+    final String itemVar = variableName != null ? variableName + "Item" : ParserCommonUtils.getVariableNameForLevel(level, "Item");
+    final String tempListVar = variableName != null ? variableName + "TempList" : ParserCommonUtils.getVariableNameForLevel(level, "TempList");
 
     // Cannot directly create generic array T[]. Create List first, then convert.
     // 1. Get the JSON Array - Use $T for ClassName

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/CollectionFieldParser.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/CollectionFieldParser.java
@@ -111,14 +111,14 @@ public class CollectionFieldParser implements TypeParser {
 
     // Determine implementation and set resultVarName prefix
     if (variableDeclarationType instanceof Class<?> && Set.class.isAssignableFrom((Class<?>) variableDeclarationType)) {
-      resultVarName = variableName != null ? variableName : ParserCommonUtils.getVariableNameForLevel(level, "Set");
+      resultVarName = ParserCommonUtils.localVarName(variableName, "", level, "Set");
       collectionImpl = HASH_SET;
     } else if (variableDeclarationType instanceof ParameterizedType
         && Set.class.isAssignableFrom((Class<?>) ((ParameterizedType) variableDeclarationType).getRawType())) {
-      resultVarName = variableName != null ? variableName : ParserCommonUtils.getVariableNameForLevel(level, "Set");
+      resultVarName = ParserCommonUtils.localVarName(variableName, "", level, "Set");
       collectionImpl = HASH_SET;
     } else { // Default to List/ArrayList
-      resultVarName = variableName != null ? variableName : ParserCommonUtils.getVariableNameForLevel(level, "List");
+      resultVarName = ParserCommonUtils.localVarName(variableName, "", level, "List");
       collectionImpl = ARRAY_LIST;
     }
 
@@ -129,9 +129,8 @@ public class CollectionFieldParser implements TypeParser {
       return resultVarName;
     }
 
-    // Prefix siblings with the field name (constructor path) or fall back to level-based names.
-    final String arrayVar = variableName != null ? variableName + "Array" : ParserCommonUtils.getVariableNameForLevel(level, "Array");
-    final String itemVar = variableName != null ? variableName + "Item" : ParserCommonUtils.getVariableNameForLevel(level, "Item");
+    final String arrayVar = ParserCommonUtils.localVarName(variableName, "Array", level, "Array");
+    final String itemVar = ParserCommonUtils.localVarName(variableName, "Item", level, "Item");
 
     // 1. Get JSON Array
     code.addStatement("final $T $L = $L", ParserCommonUtils.getJSONArrayHandle(), arrayVar, accessExpression);
@@ -187,11 +186,10 @@ public class CollectionFieldParser implements TypeParser {
   private String generateObjectArrayParsingCodeInto(final CodeBlock.Builder code, final Class<?> arrayRuntimeType, final String parserPackage,
       final CodeBlock accessExpression, final int level, final Type fieldType, final String variableName) {
     final Type componentType = arrayRuntimeType.getComponentType();
-    // Prefix siblings with the field name (constructor path) or fall back to level-based names.
-    final String resultVarName = variableName != null ? variableName : ParserCommonUtils.getVariableNameForLevel(level, "Array");
-    final String arrayJsonVar = variableName != null ? variableName + "JsonArray" : ParserCommonUtils.getVariableNameForLevel(level, "JsonArray");
-    final String itemVar = variableName != null ? variableName + "Item" : ParserCommonUtils.getVariableNameForLevel(level, "Item");
-    final String indexVar = variableName != null ? variableName + "Index" : ParserCommonUtils.getVariableNameForLevel(level, "Index");
+    final String resultVarName = ParserCommonUtils.localVarName(variableName, "", level, "Array");
+    final String arrayJsonVar = ParserCommonUtils.localVarName(variableName, "JsonArray", level, "JsonArray");
+    final String itemVar = ParserCommonUtils.localVarName(variableName, "Item", level, "Item");
+    final String indexVar = ParserCommonUtils.localVarName(variableName, "Index", level, "Index");
 
     // 1. Get the JSON Array - Use $T for ClassName
     code.addStatement("final $T $L = $L", ParserCommonUtils.getJSONArrayHandle(), arrayJsonVar, accessExpression);
@@ -228,10 +226,10 @@ public class CollectionFieldParser implements TypeParser {
   private String generateGenericArrayParsingCodeInto(final CodeBlock.Builder code, final java.lang.reflect.GenericArrayType arrayRuntimeType,
       final String parserPackage, final CodeBlock accessExpression, final int level, final Type fieldType, final String variableName) {
     final Type componentType = arrayRuntimeType.getGenericComponentType();
-    final String resultVarName = variableName != null ? variableName : ParserCommonUtils.getVariableNameForLevel(level, "Array");
-    final String arrayJsonVar = variableName != null ? variableName + "JsonArray" : ParserCommonUtils.getVariableNameForLevel(level, "JsonArray");
-    final String itemVar = variableName != null ? variableName + "Item" : ParserCommonUtils.getVariableNameForLevel(level, "Item");
-    final String tempListVar = variableName != null ? variableName + "TempList" : ParserCommonUtils.getVariableNameForLevel(level, "TempList");
+    final String resultVarName = ParserCommonUtils.localVarName(variableName, "", level, "Array");
+    final String arrayJsonVar = ParserCommonUtils.localVarName(variableName, "JsonArray", level, "JsonArray");
+    final String itemVar = ParserCommonUtils.localVarName(variableName, "Item", level, "Item");
+    final String tempListVar = ParserCommonUtils.localVarName(variableName, "TempList", level, "TempList");
 
     // Cannot directly create generic array T[]. Create List first, then convert.
     // 1. Get the JSON Array - Use $T for ClassName

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/CustomObjectFieldParser.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/CustomObjectFieldParser.java
@@ -23,24 +23,29 @@ public class CustomObjectFieldParser implements TypeParser {
     // Check if it's a class type first
     if (type instanceof Class<?>) {
       Class<?> clazz = (Class<?>) type;
-        // Handle non-primitive, non-Collection, non-Map, non-array, non-enum types
-        return !clazz.isPrimitive() &&
-            !Collection.class.isAssignableFrom(clazz) &&
-            !Map.class.isAssignableFrom(clazz) &&
-            !clazz.isArray() &&
-            !clazz.isEnum();
-      } else if (type instanceof ParameterizedType) {
-        // Potentially handle complex parameterized types if they aren't Collections or Maps
-        // Example: CustomGeneric<String>, if we had a parser for CustomGeneric
-        Type rawType = ((ParameterizedType) type).getRawType();
-        if (rawType instanceof Class<?>) {
-          Class<?> rawClass = (Class<?>) rawType;
-          return !Collection.class.isAssignableFrom(rawClass) &&
-              !Map.class.isAssignableFrom(rawClass);
-        }
+      // User Map subclasses (e.g. `class FooMap extends HashMap`) fall through to a custom
+      // parser by simple name. JDK Maps are excluded - no `MapParser` exists to dispatch to.
+      return !clazz.isPrimitive() &&
+          !Collection.class.isAssignableFrom(clazz) &&
+          !clazz.isArray() &&
+          !clazz.isEnum() &&
+          !isJdkMap(clazz);
+    } else if (type instanceof ParameterizedType) {
+      // Potentially handle complex parameterized types if they aren't Collections or Maps
+      // Example: CustomGeneric<String>, if we had a parser for CustomGeneric
+      Type rawType = ((ParameterizedType) type).getRawType();
+      if (rawType instanceof Class<?>) {
+        Class<?> rawClass = (Class<?>) rawType;
+        return !Collection.class.isAssignableFrom(rawClass) &&
+            !Map.class.isAssignableFrom(rawClass);
       }
-      // Doesn't handle other types like TypeVariable, WildcardType, GenericArrayType directly
-      return false;
+    }
+    // Doesn't handle other types like TypeVariable, WildcardType, GenericArrayType directly
+    return false;
+  }
+
+  private static boolean isJdkMap(final Class<?> clazz) {
+    return Map.class.isAssignableFrom(clazz) && clazz.getName().startsWith("java.");
   }
 
   @Override

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/MapFieldParser.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/MapFieldParser.java
@@ -90,7 +90,7 @@ public class MapFieldParser implements TypeParser {
       mapImpl = ClassName.get(java.util.LinkedHashMap.class);
     }
 
-    final String mapVar = variableName != null ? variableName : ParserCommonUtils.getVariableNameForLevel(level, "Map");
+    final String mapVar = ParserCommonUtils.localVarName(variableName, "", level, "Map");
     final String objVar = ParserCommonUtils.getVariableNameForLevel(level, "Obj");
     final String keyVar = ParserCommonUtils.getVariableNameForLevel(level, "Key");
 

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/MapFieldParser.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/MapFieldParser.java
@@ -57,6 +57,13 @@ public class MapFieldParser implements TypeParser {
   public String generateParsingCodeInto(final CodeBlock.Builder code, final Type type, final String objVarName, final String parserPackage,
       final CodeBlock accessExpression,
       final int level, final Type fieldType) {
+    return generateParsingCodeInto(code, type, objVarName, parserPackage, accessExpression, level, fieldType, null);
+  }
+
+  @Override
+  public String generateParsingCodeInto(final CodeBlock.Builder code, final Type type, final String objVarName, final String parserPackage,
+      final CodeBlock accessExpression,
+      final int level, final Type fieldType, final String variableName) {
     if (!canHandle(type)) {
       throw new IllegalArgumentException("MapFieldParser cannot handle type: " + type.getTypeName());
     }
@@ -83,7 +90,7 @@ public class MapFieldParser implements TypeParser {
       mapImpl = ClassName.get(java.util.LinkedHashMap.class);
     }
 
-    final String mapVar = ParserCommonUtils.getVariableNameForLevel(level, "Map");
+    final String mapVar = variableName != null ? variableName : ParserCommonUtils.getVariableNameForLevel(level, "Map");
     final String objVar = ParserCommonUtils.getVariableNameForLevel(level, "Obj");
     final String keyVar = ParserCommonUtils.getVariableNameForLevel(level, "Key");
 

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/ParserCommonUtils.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/ParserCommonUtils.java
@@ -126,6 +126,17 @@ public final class ParserCommonUtils {
   }
 
   /**
+   * If {@code variableName} is set, returns {@code variableName + variableAffix};
+   * otherwise falls back to {@link #getVariableNameForLevel}.
+   */
+  public static String localVarName(final String variableName, final String variableAffix,
+      final int fallbackLevel, final String fallbackLevelName) {
+    return variableName != null
+        ? variableName + variableAffix
+        : getVariableNameForLevel(fallbackLevel, fallbackLevelName);
+  }
+
+  /**
    * Generates a variable name based on the nesting level.
    * Level 1 uses the base suffix directly (e.g., "value", "map").
    * Levels > 1 prepend "levelN" (e.g., "level2Value", "level3Map").

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/ParserCommonUtils.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/ParserCommonUtils.java
@@ -108,6 +108,14 @@ public final class ParserCommonUtils {
   }
 
   /**
+   * Strips type arguments from a source-level type name: {@code "List<String>"} → {@code "List"}.
+   */
+  public static String stripGenerics(final String typeName) {
+    final int genericStart = typeName.indexOf('<');
+    return (genericStart < 0 ? typeName : typeName.substring(0, genericStart)).trim();
+  }
+
+  /**
    * Capitalizes the first letter of a string.
    */
   public static String capitalize(final String str) {

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/PrimitiveArrayFieldParser.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/PrimitiveArrayFieldParser.java
@@ -39,11 +39,17 @@ public class PrimitiveArrayFieldParser implements TypeParser {
   @Override
   public String generateParsingCodeInto(CodeBlock.Builder code, Type type, String objVarName, String parserPackage, CodeBlock accessExpression,
       int level, Type fieldType) {
+    return generateParsingCodeInto(code, type, objVarName, parserPackage, accessExpression, level, fieldType, null);
+  }
+
+  @Override
+  public String generateParsingCodeInto(CodeBlock.Builder code, Type type, String objVarName, String parserPackage, CodeBlock accessExpression,
+      int level, Type fieldType, String variableName) {
     if (!canHandle(type)) {
       throw new IllegalArgumentException("PrimitiveArrayFieldParser cannot handle type: " + type.getTypeName());
     }
 
-    // --- Extract simple field name from accessExpression --- 
+    // --- Extract simple field name from accessExpression ---
     String accessExpressionString = accessExpression.toString();
     String fieldNameString = "";
     int lastQuote = accessExpressionString.lastIndexOf('"');
@@ -65,7 +71,7 @@ public class PrimitiveArrayFieldParser implements TypeParser {
     Class<?> arrayType = (Class<?>) type;
     Class<?> componentType = arrayType.getComponentType();
     TypeName declarationTypeName = TypeName.get(fieldType);
-    String resultVarName = ParserCommonUtils.getVariableNameForLevel(level, "Array");
+    String resultVarName = variableName != null ? variableName : ParserCommonUtils.getVariableNameForLevel(level, "Array");
 
     code.addStatement("$T $L = null", declarationTypeName, resultVarName);
 
@@ -83,11 +89,11 @@ public class PrimitiveArrayFieldParser implements TypeParser {
     } else {
       // Should not happen due to canHandle check
         code.endControlFlow();
-        return resultVarName; 
+        return resultVarName;
     }
 
-    String jsonArrayVar = ParserCommonUtils.getVariableNameForLevel(level, "JsonArray");
-    String listVarName = ParserCommonUtils.getVariableNameForLevel(level, "TempList");
+    String jsonArrayVar = variableName != null ? variableName + "JsonArray" : ParserCommonUtils.getVariableNameForLevel(level, "JsonArray");
+    String listVarName = variableName != null ? variableName + "TempList" : ParserCommonUtils.getVariableNameForLevel(level, "TempList");
     ClassName jsonArrayHandleName = ParserCommonUtils.getJSONArrayHandle();
     ClassName arrayListName = ClassName.get(java.util.ArrayList.class);
     TypeName wrapperListName = ParameterizedTypeName.get(ClassName.get(java.util.List.class), ClassName.get(wrapperType));

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/PrimitiveArrayFieldParser.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/PrimitiveArrayFieldParser.java
@@ -71,7 +71,7 @@ public class PrimitiveArrayFieldParser implements TypeParser {
     Class<?> arrayType = (Class<?>) type;
     Class<?> componentType = arrayType.getComponentType();
     TypeName declarationTypeName = TypeName.get(fieldType);
-    String resultVarName = variableName != null ? variableName : ParserCommonUtils.getVariableNameForLevel(level, "Array");
+    String resultVarName = ParserCommonUtils.localVarName(variableName, "", level, "Array");
 
     code.addStatement("$T $L = null", declarationTypeName, resultVarName);
 
@@ -92,8 +92,8 @@ public class PrimitiveArrayFieldParser implements TypeParser {
         return resultVarName;
     }
 
-    String jsonArrayVar = variableName != null ? variableName + "JsonArray" : ParserCommonUtils.getVariableNameForLevel(level, "JsonArray");
-    String listVarName = variableName != null ? variableName + "TempList" : ParserCommonUtils.getVariableNameForLevel(level, "TempList");
+    String jsonArrayVar = ParserCommonUtils.localVarName(variableName, "JsonArray", level, "JsonArray");
+    String listVarName = ParserCommonUtils.localVarName(variableName, "TempList", level, "TempList");
     ClassName jsonArrayHandleName = ParserCommonUtils.getJSONArrayHandle();
     ClassName arrayListName = ClassName.get(java.util.ArrayList.class);
     TypeName wrapperListName = ParameterizedTypeName.get(ClassName.get(java.util.List.class), ClassName.get(wrapperType));

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/TypeParser.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/TypeParser.java
@@ -56,23 +56,14 @@ public interface TypeParser {
         CodeBlock accessExpression, int level, Type fieldType);
 
     /**
-     * Generates parsing code with a specific variable name override.
-     * Default implementation delegates to the standard method, ignoring the variable name.
-     * Implementations can override this to use the provided variable name.
-     *
-     * @param code The CodeBlock.Builder to add generated code to.
-     * @param type The runtime Type being parsed.
-     * @param objVarName The variable name of the parent JSONObjectHandle.
-     * @param parserPackage The package for generated parsers.
-     * @param accessExpression A CodeBlock representing how to access the raw JSON data.
-     * @param level The current nesting level.
-     * @param fieldType The exact generic type of the original field/setter parameter.
-     * @param variableName The desired variable name for the parsed value, or null for default naming.
-     * @return The name of the variable declared within the generated code block.
+     * Generates parsing code with a variable-name override. Used by the constructor-based path so
+     * each parsed field's local has the field's own name. When {@code variableName} is non-null,
+     * implementations use it as the result variable name and as a prefix for sibling locals
+     * (e.g. {@code names} → {@code namesArray}, {@code namesItem}). When null, fall back to
+     * level-based naming so legacy setter-based output stays byte-identical.
      */
     default String generateParsingCodeInto(CodeBlock.Builder code, Type type, String objVarName, String parserPackage,
         CodeBlock accessExpression, int level, Type fieldType, String variableName) {
-        // Default: ignore variableName and use standard method
         return generateParsingCodeInto(code, type, objVarName, parserPackage, accessExpression, level, fieldType);
     }
 }

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/validator/ConfigurationValidator.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/validator/ConfigurationValidator.java
@@ -419,6 +419,11 @@ public class ConfigurationValidator {
 
   private boolean validateGetterSetter(final Class<?> clazz, final Field field, final boolean treatErrorsAsWarnings,
       final boolean isConstructorBasedType) {
+    // Records use bare componentName() accessors (not getX()/isX()) and have no setters
+    // by definition; the getter/setter shape check does not apply.
+    if (clazz.isRecord()) {
+      return true;
+    }
     final String fieldName = field.getName();
     final String capitalizedName = fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1);
     boolean isValid = true;

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/validator/ConfigurationValidator.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/validator/ConfigurationValidator.java
@@ -283,12 +283,7 @@ public class ConfigurationValidator {
     // Check for getters without corresponding fields
     validateGettersWithoutFields(clazz); // This only prints warnings, doesn't set hasErrors
 
-    // Check all fields
-    for (final Field field : clazz.getDeclaredFields()) {
-      if (Modifier.isStatic(field.getModifiers()) || Modifier.isTransient(field.getModifiers())) {
-        continue;
-      }
-
+    for (final Field field : ConstructorAnalyzer.getParseableFields(clazz)) {
       if (!validateField(clazz, field, treatErrorsAsWarnings)) {
         classHasIssues = true;
       }

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/analyzer/ConstructorAnalyzerGenericTypesFixture.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/analyzer/ConstructorAnalyzerGenericTypesFixture.java
@@ -1,0 +1,36 @@
+package nl.aerius.codegen.analyzer;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Fixture class for {@link ConstructorAnalyzerTest} that exercises constructor
+ * parameters with generic types ({@code List<X>}, {@code Map<K, V>}, {@code Set<X>}).
+ * The class is intentionally immutable (no setters) so that the analyzer is forced
+ * to consider constructor-based parsing.
+ */
+public class ConstructorAnalyzerGenericTypesFixture {
+  private final List<String> names;
+  private final Map<String, Integer> counts;
+  private final Set<String> tags;
+
+  public ConstructorAnalyzerGenericTypesFixture(final List<String> names, final Map<String, Integer> counts,
+      final Set<String> tags) {
+    this.names = names;
+    this.counts = counts;
+    this.tags = tags;
+  }
+
+  public List<String> getNames() {
+    return names;
+  }
+
+  public Map<String, Integer> getCounts() {
+    return counts;
+  }
+
+  public Set<String> getTags() {
+    return tags;
+  }
+}

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/analyzer/ConstructorAnalyzerTest.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/analyzer/ConstructorAnalyzerTest.java
@@ -40,4 +40,20 @@ class ConstructorAnalyzerTest {
     assertArrayEquals(new Class<?>[] {List.class, Map.class, Set.class},
         info.get().getConstructor().getParameterTypes());
   }
+
+  @Test
+  void testFindMatchingConstructorInfo_forRecord_usesCanonicalConstructor() {
+    // Records resolve via getRecordComponents() and don't need source-file lookup -
+    // construct an analyzer with no source roots to prove the record path skips it.
+    final ConstructorAnalyzer reflectionOnly = new ConstructorAnalyzer(List.of(), new Logger() {});
+    final Optional<ConstructorInfo> info = reflectionOnly.findMatchingConstructorInfo(RecordFixture.class);
+
+    assertTrue(info.isPresent(), "Expected canonical record constructor to be discovered via reflection");
+    assertEquals(List.of("name", "value", "tags"), info.get().getParameterNames());
+    assertArrayEquals(new Class<?>[] {String.class, int.class, List.class},
+        info.get().getConstructor().getParameterTypes());
+  }
+
+  /** Inline record used to assert the record-specific constructor lookup path. */
+  private record RecordFixture(String name, int value, List<String> tags) {}
 }

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/analyzer/ConstructorAnalyzerTest.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/analyzer/ConstructorAnalyzerTest.java
@@ -1,0 +1,43 @@
+package nl.aerius.codegen.analyzer;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import nl.aerius.codegen.util.Logger;
+
+/**
+ * Tests for {@link ConstructorAnalyzer}, in particular the matching of source-level
+ * parameter types with reflection types when generics are involved.
+ */
+class ConstructorAnalyzerTest {
+
+  private static final List<String> SOURCE_ROOTS = List.of("src/test/java");
+
+  private ConstructorAnalyzer analyzer;
+
+  @BeforeEach
+  void setUp() {
+    analyzer = new ConstructorAnalyzer(SOURCE_ROOTS, new Logger() {});
+  }
+
+  @Test
+  void testFindMatchingConstructorInfo_withGenericParameterTypes() {
+    final Optional<ConstructorInfo> info = analyzer
+        .findMatchingConstructorInfo(ConstructorAnalyzerGenericTypesFixture.class);
+
+    assertTrue(info.isPresent(),
+        "Expected constructor-based parsing to match a constructor whose parameters are List<String>, Map<String, Integer> and Set<String>");
+    assertEquals(List.of("names", "counts", "tags"), info.get().getParameterNames());
+    assertArrayEquals(new Class<?>[] {List.class, Map.class, Set.class},
+        info.get().getConstructor().getParameterTypes());
+  }
+}

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/generator/parser/CustomObjectFieldParserTest.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/generator/parser/CustomObjectFieldParserTest.java
@@ -1,0 +1,41 @@
+package nl.aerius.codegen.generator.parser;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the canHandle dispatch guards on CustomObjectFieldParser, in particular the
+ * JDK-Map exclusion that prevents raw java.util Map types from routing to a
+ * non-existent generated parser, while still letting user Map subclasses fall through
+ * so they can be picked up by a custom parser.
+ */
+class CustomObjectFieldParserTest {
+
+  private final CustomObjectFieldParser parser = new CustomObjectFieldParser(new HashMap<>());
+
+  @Test
+  void canHandleRejectsRawJdkMapTypes() {
+    assertFalse(parser.canHandle(Map.class), "raw Map should not route to CustomObjectFieldParser");
+    assertFalse(parser.canHandle(HashMap.class), "raw HashMap should not route to CustomObjectFieldParser");
+    assertFalse(parser.canHandle(LinkedHashMap.class), "raw LinkedHashMap should not route to CustomObjectFieldParser");
+    assertFalse(parser.canHandle(TreeMap.class), "raw TreeMap should not route to CustomObjectFieldParser");
+  }
+
+  @Test
+  void canHandleAcceptsUserMapSubclass() {
+    assertTrue(parser.canHandle(UserMapSubclass.class),
+        "user-defined Map subclass should fall through so a custom parser can handle it by simple name");
+  }
+
+  /** User-defined Map subclass - by extending HashMap from a non-java.* package, it should not be excluded. */
+  private static final class UserMapSubclass extends HashMap<String, String> {
+    private static final long serialVersionUID = 1L;
+  }
+}

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestConstructorWithGenericsType.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestConstructorWithGenericsType.java
@@ -1,0 +1,72 @@
+package nl.aerius.codegen.test.types;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Immutable test type whose constructor parameters cover the generic-collection
+ * and primitive-array cases that exercise:
+ * - ConstructorAnalyzer matching List&lt;X&gt;/Map&lt;K,V&gt;/Set&lt;X&gt; source
+ *   types against raw reflection types (stripGenerics).
+ * - CollectionFieldParser, MapFieldParser, and PrimitiveArrayFieldParser using
+ *   the field name for their result variable (variableName overload) so sibling
+ *   constructor params don't collide on level-based names.
+ */
+public class TestConstructorWithGenericsType {
+  private final List<String> tags;
+  private final Map<String, Integer> counts;
+  private final Set<String> labels;
+  private final int[] sizes;
+  private final String[] aliases;
+
+  public TestConstructorWithGenericsType(final List<String> tags, final Map<String, Integer> counts,
+      final Set<String> labels, final int[] sizes, final String[] aliases) {
+    this.tags = tags;
+    this.counts = counts;
+    this.labels = labels;
+    this.sizes = sizes;
+    this.aliases = aliases;
+  }
+
+  public List<String> getTags() {
+    return tags;
+  }
+
+  public Map<String, Integer> getCounts() {
+    return counts;
+  }
+
+  public Set<String> getLabels() {
+    return labels;
+  }
+
+  public int[] getSizes() {
+    return sizes;
+  }
+
+  public String[] getAliases() {
+    return aliases;
+  }
+
+  public static TestConstructorWithGenericsType createFullObject() {
+    final Map<String, Integer> counts = new LinkedHashMap<>();
+    counts.put("alpha", 1);
+    counts.put("beta", 2);
+    final Set<String> labels = new HashSet<>();
+    labels.add("first");
+    labels.add("second");
+    return new TestConstructorWithGenericsType(
+        List.of("a", "b", "c"),
+        counts,
+        labels,
+        new int[] {10, 20, 30},
+        new String[] {"x", "y"});
+  }
+
+  public static TestConstructorWithGenericsType createNullObject() {
+    return new TestConstructorWithGenericsType(null, null, null, null, null);
+  }
+}

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestConstructorWithIgnoredFieldType.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestConstructorWithIgnoredFieldType.java
@@ -1,0 +1,42 @@
+package nl.aerius.codegen.test.types;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * Immutable test type with a {@code @JsonIgnore} field that is NOT a constructor
+ * parameter (it is derived from another field). Verifies that the constructor-based
+ * code path skips {@code @JsonIgnore} fields in {@code getParseableFields}, so the
+ * single-arg constructor matches the single parseable field {@code name} instead of
+ * failing because the analyzer thinks there are two parseable fields.
+ *
+ * The {@code derivedHash} getter is annotated so Jackson also leaves it out of the
+ * round-trip JSON.
+ */
+public class TestConstructorWithIgnoredFieldType {
+  private final String name;
+
+  @JsonIgnore
+  private final int derivedHash;
+
+  public TestConstructorWithIgnoredFieldType(final String name) {
+    this.name = name;
+    this.derivedHash = name == null ? 0 : name.hashCode();
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @JsonIgnore
+  public int getDerivedHash() {
+    return derivedHash;
+  }
+
+  public static TestConstructorWithIgnoredFieldType createFullObject() {
+    return new TestConstructorWithIgnoredFieldType("ignored-field-test");
+  }
+
+  public static TestConstructorWithIgnoredFieldType createNullObject() {
+    return new TestConstructorWithIgnoredFieldType(null);
+  }
+}

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestRecordType.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestRecordType.java
@@ -1,0 +1,19 @@
+package nl.aerius.codegen.test.types;
+
+import java.util.List;
+
+/**
+ * Java record fixture: exercises the constructor-based path against a record's
+ * compiler-generated canonical constructor and {@code getRecordComponents()}
+ * (instead of source-file parsing). Includes a generic collection component to
+ * also exercise the variableName-aware collection parser.
+ */
+public record TestRecordType(String name, int value, List<String> tags) {
+  public static TestRecordType createFullObject() {
+    return new TestRecordType("record-test", 7, List.of("alpha", "beta"));
+  }
+
+  public static TestRecordType createNullObject() {
+    return new TestRecordType(null, 0, null);
+  }
+}

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestRootObjectType.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestRootObjectType.java
@@ -25,6 +25,7 @@ public class TestRootObjectType {
   private TestConstructorBasedType constructorBased;
   private TestConstructorWithGenericsType constructorWithGenerics;
   private TestConstructorWithIgnoredFieldType constructorWithIgnoredField;
+  private TestRecordType recordType;
 
   public String getFoo() {
     return foo;
@@ -162,6 +163,14 @@ public class TestRootObjectType {
     this.constructorWithIgnoredField = constructorWithIgnoredField;
   }
 
+  public TestRecordType getRecordType() {
+    return recordType;
+  }
+
+  public void setRecordType(TestRecordType recordType) {
+    this.recordType = recordType;
+  }
+
   public static TestRootObjectType createFullObject() {
     TestRootObjectType obj = new TestRootObjectType();
     obj.setFoo("test string");
@@ -181,6 +190,7 @@ public class TestRootObjectType {
     obj.setConstructorBased(TestConstructorBasedType.createFullObject());
     obj.setConstructorWithGenerics(TestConstructorWithGenericsType.createFullObject());
     obj.setConstructorWithIgnoredField(TestConstructorWithIgnoredFieldType.createFullObject());
+    obj.setRecordType(TestRecordType.createFullObject());
     return obj;
   }
 

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestRootObjectType.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestRootObjectType.java
@@ -23,6 +23,8 @@ public class TestRootObjectType {
   private TestPolyBase testPolyBase;
   private TestPrimitiveArrayType primitiveArrays;
   private TestConstructorBasedType constructorBased;
+  private TestConstructorWithGenericsType constructorWithGenerics;
+  private TestConstructorWithIgnoredFieldType constructorWithIgnoredField;
 
   public String getFoo() {
     return foo;
@@ -144,6 +146,22 @@ public class TestRootObjectType {
     this.constructorBased = constructorBased;
   }
 
+  public TestConstructorWithGenericsType getConstructorWithGenerics() {
+    return constructorWithGenerics;
+  }
+
+  public void setConstructorWithGenerics(TestConstructorWithGenericsType constructorWithGenerics) {
+    this.constructorWithGenerics = constructorWithGenerics;
+  }
+
+  public TestConstructorWithIgnoredFieldType getConstructorWithIgnoredField() {
+    return constructorWithIgnoredField;
+  }
+
+  public void setConstructorWithIgnoredField(TestConstructorWithIgnoredFieldType constructorWithIgnoredField) {
+    this.constructorWithIgnoredField = constructorWithIgnoredField;
+  }
+
   public static TestRootObjectType createFullObject() {
     TestRootObjectType obj = new TestRootObjectType();
     obj.setFoo("test string");
@@ -161,6 +179,8 @@ public class TestRootObjectType {
     obj.setTestPolyBase(new TestPolySubA("BaseValueA", 123));
     obj.setPrimitiveArrays(TestPrimitiveArrayType.createFullObject());
     obj.setConstructorBased(TestConstructorBasedType.createFullObject());
+    obj.setConstructorWithGenerics(TestConstructorWithGenericsType.createFullObject());
+    obj.setConstructorWithIgnoredField(TestConstructorWithIgnoredFieldType.createFullObject());
     return obj;
   }
 

--- a/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestAdvancedMapTypeParser.java
+++ b/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestAdvancedMapTypeParser.java
@@ -80,8 +80,6 @@ public class TestAdvancedMapTypeParser {
       config.setObjectListMap(map);
     }
 
-    // Skipping ignored field: interfaceMap
-
     // Parse complexKeyMap
     if (baseObj.has("complexKeyMap") && !baseObj.isNull("complexKeyMap")) {
       final JSONObjectHandle obj = baseObj.getObject("complexKeyMap");
@@ -92,10 +90,6 @@ public class TestAdvancedMapTypeParser {
       });
       config.setComplexKeyMap(map);
     }
-
-    // Skipping ignored field: wildcardListMap
-
-    // Skipping ignored field: wildcardKeyMap
 
     // Parse sanity
     if (baseObj.has("sanity") && !baseObj.isNull("sanity")) {

--- a/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestConstructorWithGenericsTypeParser.java
+++ b/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestConstructorWithGenericsTypeParser.java
@@ -1,0 +1,84 @@
+package nl.aerius.codegen.test.generated;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.processing.Generated;
+
+import nl.aerius.codegen.test.types.TestConstructorWithGenericsType;
+import nl.aerius.json.JSONArrayHandle;
+import nl.aerius.json.JSONObjectHandle;
+
+@Generated(value = "nl.aerius.codegen.ParserGenerator", date = "2024-01-01T00:00:00")
+public class TestConstructorWithGenericsTypeParser {
+  public static TestConstructorWithGenericsType parse(final String jsonText) {
+    if (jsonText == null) {
+      return null;
+    }
+
+    return parse(JSONObjectHandle.fromText(jsonText));
+  }
+
+  public static TestConstructorWithGenericsType parse(final JSONObjectHandle baseObj) {
+    if (baseObj == null) {
+      return null;
+    }
+
+    // Parse tags
+    if (!baseObj.has("tags")) {
+      throw new RuntimeException("Required field 'tags' is missing");
+    }
+    final JSONArrayHandle tagsArray = baseObj.getArray("tags");
+    final List<String> tags = new ArrayList<>();
+    tagsArray.forEachString(tags::add);
+
+    // Parse counts
+    if (!baseObj.has("counts")) {
+      throw new RuntimeException("Required field 'counts' is missing");
+    }
+    final JSONObjectHandle obj = baseObj.getObject("counts");
+    final Map<String, Integer> counts = new LinkedHashMap<>();
+    obj.keySet().forEach(key -> {
+      final Integer level2Value = obj.getInteger(key);
+      counts.put(key, level2Value);
+    });
+
+    // Parse labels
+    if (!baseObj.has("labels")) {
+      throw new RuntimeException("Required field 'labels' is missing");
+    }
+    final JSONArrayHandle labelsArray = baseObj.getArray("labels");
+    final Set<String> labels = new HashSet<>();
+    labelsArray.forEachString(labels::add);
+
+    // Parse sizes
+    if (!baseObj.has("sizes")) {
+      throw new RuntimeException("Required field 'sizes' is missing");
+    }
+    int[] sizes = null;
+    final JSONArrayHandle sizesJsonArray = baseObj.getArray("sizes");
+    if (sizesJsonArray != null) {
+      final List<Integer> sizesTempList = new ArrayList<>();
+      sizesJsonArray.forEachInteger(sizesTempList::add);
+      sizes = sizesTempList.stream().mapToInt(i -> i != null ? i.intValue() : 0).toArray();
+    }
+
+    // Parse aliases
+    if (!baseObj.has("aliases")) {
+      throw new RuntimeException("Required field 'aliases' is missing");
+    }
+    String[] aliases = null;
+    final JSONArrayHandle aliasesJsonArray = baseObj.getArray("aliases");
+    if (aliasesJsonArray != null) {
+      final List<String> aliasesTempList = new ArrayList<>();
+      aliasesJsonArray.forEachString(aliasesTempList::add);
+      aliases = aliasesTempList.toArray(new String[0]);
+    }
+
+    return new TestConstructorWithGenericsType(tags, counts, labels, sizes, aliases);
+  }
+}

--- a/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestConstructorWithIgnoredFieldTypeParser.java
+++ b/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestConstructorWithIgnoredFieldTypeParser.java
@@ -1,0 +1,31 @@
+package nl.aerius.codegen.test.generated;
+
+import javax.annotation.processing.Generated;
+
+import nl.aerius.codegen.test.types.TestConstructorWithIgnoredFieldType;
+import nl.aerius.json.JSONObjectHandle;
+
+@Generated(value = "nl.aerius.codegen.ParserGenerator", date = "2024-01-01T00:00:00")
+public class TestConstructorWithIgnoredFieldTypeParser {
+  public static TestConstructorWithIgnoredFieldType parse(final String jsonText) {
+    if (jsonText == null) {
+      return null;
+    }
+
+    return parse(JSONObjectHandle.fromText(jsonText));
+  }
+
+  public static TestConstructorWithIgnoredFieldType parse(final JSONObjectHandle baseObj) {
+    if (baseObj == null) {
+      return null;
+    }
+
+    // Parse name
+    if (!baseObj.has("name")) {
+      throw new RuntimeException("Required field 'name' is missing");
+    }
+    final String name = baseObj.getString("name");
+
+    return new TestConstructorWithIgnoredFieldType(name);
+  }
+}

--- a/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestRecordTypeParser.java
+++ b/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestRecordTypeParser.java
@@ -1,0 +1,49 @@
+package nl.aerius.codegen.test.generated;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.processing.Generated;
+
+import nl.aerius.codegen.test.types.TestRecordType;
+import nl.aerius.json.JSONArrayHandle;
+import nl.aerius.json.JSONObjectHandle;
+
+@Generated(value = "nl.aerius.codegen.ParserGenerator", date = "2024-01-01T00:00:00")
+public class TestRecordTypeParser {
+  public static TestRecordType parse(final String jsonText) {
+    if (jsonText == null) {
+      return null;
+    }
+
+    return parse(JSONObjectHandle.fromText(jsonText));
+  }
+
+  public static TestRecordType parse(final JSONObjectHandle baseObj) {
+    if (baseObj == null) {
+      return null;
+    }
+
+    // Parse name
+    if (!baseObj.has("name")) {
+      throw new RuntimeException("Required field 'name' is missing");
+    }
+    final String name = baseObj.getString("name");
+
+    // Parse value
+    if (!baseObj.has("value")) {
+      throw new RuntimeException("Required field 'value' is missing");
+    }
+    final int value = baseObj.getInteger("value");
+
+    // Parse tags
+    if (!baseObj.has("tags")) {
+      throw new RuntimeException("Required field 'tags' is missing");
+    }
+    final JSONArrayHandle tagsArray = baseObj.getArray("tags");
+    final List<String> tags = new ArrayList<>();
+    tagsArray.forEachString(tags::add);
+
+    return new TestRecordType(name, value, tags);
+  }
+}

--- a/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestRootObjectTypeParser.java
+++ b/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestRootObjectTypeParser.java
@@ -7,6 +7,8 @@ import nl.aerius.codegen.test.types.ConcreteType;
 import nl.aerius.codegen.test.types.TestAdvancedMapType;
 import nl.aerius.codegen.test.types.TestComplexCollectionType;
 import nl.aerius.codegen.test.types.TestConstructorBasedType;
+import nl.aerius.codegen.test.types.TestConstructorWithGenericsType;
+import nl.aerius.codegen.test.types.TestConstructorWithIgnoredFieldType;
 import nl.aerius.codegen.test.types.TestCustomParserType;
 import nl.aerius.codegen.test.types.TestEnumListType;
 import nl.aerius.codegen.test.types.TestEnumType;
@@ -131,6 +133,18 @@ public class TestRootObjectTypeParser {
     if (baseObj.has("constructorBased") && !baseObj.isNull("constructorBased")) {
       final TestConstructorBasedType value = TestConstructorBasedTypeParser.parse(baseObj.getObject("constructorBased"));
       config.setConstructorBased(value);
+    }
+
+    // Parse constructorWithGenerics
+    if (baseObj.has("constructorWithGenerics") && !baseObj.isNull("constructorWithGenerics")) {
+      final TestConstructorWithGenericsType value = TestConstructorWithGenericsTypeParser.parse(baseObj.getObject("constructorWithGenerics"));
+      config.setConstructorWithGenerics(value);
+    }
+
+    // Parse constructorWithIgnoredField
+    if (baseObj.has("constructorWithIgnoredField") && !baseObj.isNull("constructorWithIgnoredField")) {
+      final TestConstructorWithIgnoredFieldType value = TestConstructorWithIgnoredFieldTypeParser.parse(baseObj.getObject("constructorWithIgnoredField"));
+      config.setConstructorWithIgnoredField(value);
     }
   }
 }

--- a/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestRootObjectTypeParser.java
+++ b/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestRootObjectTypeParser.java
@@ -14,6 +14,7 @@ import nl.aerius.codegen.test.types.TestEnumListType;
 import nl.aerius.codegen.test.types.TestEnumType;
 import nl.aerius.codegen.test.types.TestNestedMapType;
 import nl.aerius.codegen.test.types.TestPrimitiveArrayType;
+import nl.aerius.codegen.test.types.TestRecordType;
 import nl.aerius.codegen.test.types.TestRootObjectType;
 import nl.aerius.codegen.test.types.TestSimpleCollectionType;
 import nl.aerius.codegen.test.types.TestSimpleTypesType;
@@ -145,6 +146,12 @@ public class TestRootObjectTypeParser {
     if (baseObj.has("constructorWithIgnoredField") && !baseObj.isNull("constructorWithIgnoredField")) {
       final TestConstructorWithIgnoredFieldType value = TestConstructorWithIgnoredFieldTypeParser.parse(baseObj.getObject("constructorWithIgnoredField"));
       config.setConstructorWithIgnoredField(value);
+    }
+
+    // Parse recordType
+    if (baseObj.has("recordType") && !baseObj.isNull("recordType")) {
+      final TestRecordType value = TestRecordTypeParser.parse(baseObj.getObject("recordType"));
+      config.setRecordType(value);
     }
   }
 }


### PR DESCRIPTION
- Honor @JsonIgnore consistently across analyzer, validator and generator
- Match generic constructor params (List<String> against raw List)
- Use field names for constructor-bound local variables
- Allow user Map subclasses to dispatch to custom parsers
- Drop dead JsonIgnore reflection lookup in ParserWriterUtils
- Extract stripGenerics into a shared util
- ~~Bump version to 1.1.1-SNAPSHOT~~
- Tests for all of the above via t1-t3 pipeline

~~There is also #15 which updates to 1.2.0-SNAPSHOT - if that gets merged before this, will rebase on top.~~

Also, didn't intend for this, but perhaps most crucially this PR adds:

- Record support

So now, we are no longer in the way of migrating existing POJOs to records. 🎉 

---

This will make the constructor parser much more capable and allow phase 2 of the one-call-to-rule-them-all upgrades over in calculator