### PR TITLE
Honor @JsonProperty for wire key and accessor names

### DIFF
--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriterUtils.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriterUtils.java
@@ -403,20 +403,21 @@ public final class ParserWriterUtils {
    */
   private static String generateFieldParsingCode(final MethodSpec.Builder methodBuilder, final Field field,
       final String parserPackage) {
+    final String jsonKey = ParserCommonUtils.jsonKeyFor(field);
     methodBuilder.addCode("\n");
     methodBuilder.addComment("Parse $L", field.getName());
 
     // Check if field is required (must exist in JSON)
-    methodBuilder.beginControlFlow("if (!$L.has($S))", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, field.getName())
+    methodBuilder.beginControlFlow("if (!$L.has($S))", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, jsonKey)
         .addStatement("throw new $T($S)", RuntimeException.class,
-            "Required field '" + field.getName() + "' is missing")
+            "Required field '" + jsonKey + "' is missing")
         .endControlFlow();
 
     // Create access expression for this field
     final CodeBlock fieldAccess = ParserCommonUtils.createFieldAccessCode(
         field.getGenericType(),
         ParserCommonUtils.BASE_OBJECT_PARAM_NAME,
-        CodeBlock.of("$S", field.getName()));
+        CodeBlock.of("$S", jsonKey));
 
     // Use existing TypeParser infrastructure to generate parsing code with field name as variable name
     final CodeBlock.Builder parseCode = CodeBlock.builder();
@@ -454,18 +455,19 @@ public final class ParserWriterUtils {
     }
 
     for (final Field field : ConstructorAnalyzer.getParseableFields(targetClass)) {
+      final String jsonKey = ParserCommonUtils.jsonKeyFor(field);
       methodBuilder.addCode("\n");
       methodBuilder.addComment("Parse $L", field.getName());
       final boolean requireNonNull = !ParserCommonUtils.isPrimitiveType(field.getGenericType());
       methodBuilder.addCode(ParserCommonUtils.createFieldExistsCheck(
           ParserCommonUtils.BASE_OBJECT_PARAM_NAME,
-          field.getName(),
+          jsonKey,
           requireNonNull,
           innerCode -> {
             final CodeBlock fieldAccess = ParserCommonUtils.createFieldAccessCode(
                 field.getGenericType(),
                 ParserCommonUtils.BASE_OBJECT_PARAM_NAME,
-                CodeBlock.of("$S", field.getName()));
+                CodeBlock.of("$S", jsonKey));
 
             final String resultVar = dispatchGenerateParsingCodeInto(
                 innerCode,
@@ -475,7 +477,7 @@ public final class ParserWriterUtils {
                 fieldAccess,
                 1,
                 field.getGenericType());
-            innerCode.addStatement("config.set$L($L)", ParserCommonUtils.capitalize(field.getName()), resultVar);
+            innerCode.addStatement("config.set$L($L)", ParserCommonUtils.capitalize(jsonKey), resultVar);
           }));
     }
 

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/ParserCommonUtils.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/ParserCommonUtils.java
@@ -117,16 +117,9 @@ public final class ParserCommonUtils {
     return (genericStart < 0 ? typeName : typeName.substring(0, genericStart)).trim();
   }
 
-  /**
-   * Returns the JSON key the wire uses for a field. Honors {@code @JsonProperty("foo")} when
-   * present and non-empty, falling back to the Java field name otherwise. Use this everywhere
-   * the generator/validator needs to refer to the field by its wire name (JSON keys, setter
-   * derivation), so a field like {@code @JsonProperty("id") private int assessmentAreaId} reads
-   * from {@code "id"} and binds to {@code setId(...)} rather than {@code setAssessmentAreaId(...)}.
-   */
   public static String jsonKeyFor(final Field field) {
     final JsonProperty ann = field.getAnnotation(JsonProperty.class);
-    if (ann != null && ann.value() != null && !ann.value().isEmpty()) {
+    if (ann != null && !ann.value().isEmpty()) {
       return ann.value();
     }
     return field.getName();

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/ParserCommonUtils.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/ParserCommonUtils.java
@@ -1,5 +1,6 @@
 package nl.aerius.codegen.generator.parser;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
@@ -11,6 +12,7 @@ import java.util.function.Consumer;
 
 import javax.annotation.processing.Generated;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.palantir.javapoet.AnnotationSpec;
 import com.palantir.javapoet.ClassName;
 import com.palantir.javapoet.CodeBlock;
@@ -113,6 +115,21 @@ public final class ParserCommonUtils {
   public static String stripGenerics(final String typeName) {
     final int genericStart = typeName.indexOf('<');
     return (genericStart < 0 ? typeName : typeName.substring(0, genericStart)).trim();
+  }
+
+  /**
+   * Returns the JSON key the wire uses for a field. Honors {@code @JsonProperty("foo")} when
+   * present and non-empty, falling back to the Java field name otherwise. Use this everywhere
+   * the generator/validator needs to refer to the field by its wire name (JSON keys, setter
+   * derivation), so a field like {@code @JsonProperty("id") private int assessmentAreaId} reads
+   * from {@code "id"} and binds to {@code setId(...)} rather than {@code setAssessmentAreaId(...)}.
+   */
+  public static String jsonKeyFor(final Field field) {
+    final JsonProperty ann = field.getAnnotation(JsonProperty.class);
+    if (ann != null && ann.value() != null && !ann.value().isEmpty()) {
+      return ann.value();
+    }
+    return field.getName();
   }
 
   /**

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/validator/ConfigurationValidator.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/validator/ConfigurationValidator.java
@@ -29,6 +29,7 @@ import jsinterop.annotations.JsProperty;
 
 import nl.aerius.codegen.analyzer.ConstructorAnalyzer;
 import nl.aerius.codegen.analyzer.TypeAnalyzer;
+import nl.aerius.codegen.generator.parser.ParserCommonUtils;
 import nl.aerius.codegen.util.ClassFinder;
 import nl.aerius.codegen.util.FileUtils;
 import nl.aerius.codegen.util.Logger;
@@ -425,7 +426,9 @@ public class ConfigurationValidator {
       return true;
     }
     final String fieldName = field.getName();
-    final String capitalizedName = fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1);
+    // Accessors follow the JSON key (so @JsonProperty("id") on assessmentAreaId looks up getId, not
+    // getAssessmentAreaId). Without an annotation, this reduces to the field name as before.
+    final String capitalizedName = ParserCommonUtils.capitalize(ParserCommonUtils.jsonKeyFor(field));
     boolean isValid = true;
     final String prefix = treatErrorsAsWarnings ? WARNING : RED_CROSS;
 
@@ -480,18 +483,22 @@ public class ConfigurationValidator {
       return isValid;
     }
 
-    // Check setter for non-constructor-based types
+    // The setter name follows the JSON key (capitalizedName), so @JsonProperty("id") on
+    // assessmentAreaId looks up setId, not setAssessmentAreaId. Mirrors what the generator emits.
+    final String setterName = "set" + capitalizedName;
     try {
-      final Method setter = clazz.getMethod("set" + capitalizedName, field.getType());
+      final Method setter = clazz.getMethod(setterName, field.getType());
       if (!Modifier.isPublic(setter.getModifiers())) {
-        logger.warn(prefix + " " + clazz.getName() + ": Field '" + fieldName + "' must have a public setter (setter not public)");
+        logger.warn(prefix + " " + clazz.getName() + ": Field '" + fieldName + "' must have a public setter '" + setterName
+            + "' (setter not public)");
         if (!treatErrorsAsWarnings) {
           hasErrors = true;
         }
         isValid = false;
       }
     } catch (final NoSuchMethodException e) {
-      logger.warn(prefix + " " + clazz.getName() + ": Field '" + fieldName + "' must have a public setter (setter not found)");
+      logger.warn(prefix + " " + clazz.getName() + ": Field '" + fieldName + "' must have a public setter '" + setterName
+          + "' (setter not found)");
       if (!treatErrorsAsWarnings) {
         hasErrors = true;
       }

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/validator/ConfigurationValidator.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/validator/ConfigurationValidator.java
@@ -426,8 +426,6 @@ public class ConfigurationValidator {
       return true;
     }
     final String fieldName = field.getName();
-    // Accessors follow the JSON key (so @JsonProperty("id") on assessmentAreaId looks up getId, not
-    // getAssessmentAreaId). Without an annotation, this reduces to the field name as before.
     final String capitalizedName = ParserCommonUtils.capitalize(ParserCommonUtils.jsonKeyFor(field));
     boolean isValid = true;
     final String prefix = treatErrorsAsWarnings ? WARNING : RED_CROSS;
@@ -483,8 +481,6 @@ public class ConfigurationValidator {
       return isValid;
     }
 
-    // The setter name follows the JSON key (capitalizedName), so @JsonProperty("id") on
-    // assessmentAreaId looks up setId, not setAssessmentAreaId. Mirrors what the generator emits.
     final String setterName = "set" + capitalizedName;
     try {
       final Method setter = clazz.getMethod(setterName, field.getType());

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestJsonPropertyRenameType.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestJsonPropertyRenameType.java
@@ -1,0 +1,47 @@
+package nl.aerius.codegen.test.types;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Exercises the {@code @JsonProperty} key/accessor rename: the Java field is named
+ * {@code assessmentAreaId} but the wire JSON uses {@code "id"}, and the accessors are
+ * {@code getId()/setId(int)} (mimicking a {@code HasId} pattern on a JsType overlay).
+ *
+ * Round-trip success here proves that the generator (a) reads from {@code "id"} in the
+ * JSON, (b) emits {@code config.setId(...)} not {@code config.setAssessmentAreaId(...)},
+ * and that the validator accepts this shape.
+ */
+public class TestJsonPropertyRenameType {
+  @JsonProperty("id")
+  private int assessmentAreaId;
+  private String name;
+
+  public int getId() {
+    return assessmentAreaId;
+  }
+
+  public void setId(final int id) {
+    this.assessmentAreaId = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public static TestJsonPropertyRenameType createFullObject() {
+    final TestJsonPropertyRenameType obj = new TestJsonPropertyRenameType();
+    obj.setId(42);
+    obj.setName("Veluwe");
+    return obj;
+  }
+
+  public static TestJsonPropertyRenameType createNullObject() {
+    final TestJsonPropertyRenameType obj = new TestJsonPropertyRenameType();
+    obj.setName(null);
+    return obj;
+  }
+}

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestJsonPropertyRenameType.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestJsonPropertyRenameType.java
@@ -2,15 +2,6 @@ package nl.aerius.codegen.test.types;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-/**
- * Exercises the {@code @JsonProperty} key/accessor rename: the Java field is named
- * {@code assessmentAreaId} but the wire JSON uses {@code "id"}, and the accessors are
- * {@code getId()/setId(int)} (mimicking a {@code HasId} pattern on a JsType overlay).
- *
- * Round-trip success here proves that the generator (a) reads from {@code "id"} in the
- * JSON, (b) emits {@code config.setId(...)} not {@code config.setAssessmentAreaId(...)},
- * and that the validator accepts this shape.
- */
 public class TestJsonPropertyRenameType {
   @JsonProperty("id")
   private int assessmentAreaId;

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestRootObjectType.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestRootObjectType.java
@@ -26,6 +26,7 @@ public class TestRootObjectType {
   private TestConstructorWithGenericsType constructorWithGenerics;
   private TestConstructorWithIgnoredFieldType constructorWithIgnoredField;
   private TestRecordType recordType;
+  private TestJsonPropertyRenameType jsonPropertyRename;
 
   public String getFoo() {
     return foo;
@@ -171,6 +172,14 @@ public class TestRootObjectType {
     this.recordType = recordType;
   }
 
+  public TestJsonPropertyRenameType getJsonPropertyRename() {
+    return jsonPropertyRename;
+  }
+
+  public void setJsonPropertyRename(TestJsonPropertyRenameType jsonPropertyRename) {
+    this.jsonPropertyRename = jsonPropertyRename;
+  }
+
   public static TestRootObjectType createFullObject() {
     TestRootObjectType obj = new TestRootObjectType();
     obj.setFoo("test string");
@@ -191,6 +200,7 @@ public class TestRootObjectType {
     obj.setConstructorWithGenerics(TestConstructorWithGenericsType.createFullObject());
     obj.setConstructorWithIgnoredField(TestConstructorWithIgnoredFieldType.createFullObject());
     obj.setRecordType(TestRecordType.createFullObject());
+    obj.setJsonPropertyRename(TestJsonPropertyRenameType.createFullObject());
     return obj;
   }
 

--- a/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestJsonPropertyRenameTypeParser.java
+++ b/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestJsonPropertyRenameTypeParser.java
@@ -1,0 +1,46 @@
+package nl.aerius.codegen.test.generated;
+
+import javax.annotation.processing.Generated;
+
+import nl.aerius.codegen.test.types.TestJsonPropertyRenameType;
+import nl.aerius.json.JSONObjectHandle;
+
+@Generated(value = "nl.aerius.codegen.ParserGenerator", date = "2024-01-01T00:00:00")
+public class TestJsonPropertyRenameTypeParser {
+  public static TestJsonPropertyRenameType parse(final String jsonText) {
+    if (jsonText == null) {
+      return null;
+    }
+
+    return parse(JSONObjectHandle.fromText(jsonText));
+  }
+
+  public static TestJsonPropertyRenameType parse(final JSONObjectHandle baseObj) {
+    if (baseObj == null) {
+      return null;
+    }
+
+    final TestJsonPropertyRenameType config = new TestJsonPropertyRenameType();
+    parse(baseObj, config);
+    return config;
+  }
+
+  public static void parse(final JSONObjectHandle baseObj,
+      final TestJsonPropertyRenameType config) {
+    if (baseObj == null || config == null) {
+      return;
+    }
+
+    // Parse assessmentAreaId
+    if (baseObj.has("id")) {
+      final int value = baseObj.getInteger("id");
+      config.setId(value);
+    }
+
+    // Parse name
+    if (baseObj.has("name") && !baseObj.isNull("name")) {
+      final String value = baseObj.getString("name");
+      config.setName(value);
+    }
+  }
+}

--- a/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestRootObjectTypeParser.java
+++ b/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestRootObjectTypeParser.java
@@ -12,6 +12,7 @@ import nl.aerius.codegen.test.types.TestConstructorWithIgnoredFieldType;
 import nl.aerius.codegen.test.types.TestCustomParserType;
 import nl.aerius.codegen.test.types.TestEnumListType;
 import nl.aerius.codegen.test.types.TestEnumType;
+import nl.aerius.codegen.test.types.TestJsonPropertyRenameType;
 import nl.aerius.codegen.test.types.TestNestedMapType;
 import nl.aerius.codegen.test.types.TestPrimitiveArrayType;
 import nl.aerius.codegen.test.types.TestRecordType;
@@ -152,6 +153,12 @@ public class TestRootObjectTypeParser {
     if (baseObj.has("recordType") && !baseObj.isNull("recordType")) {
       final TestRecordType value = TestRecordTypeParser.parse(baseObj.getObject("recordType"));
       config.setRecordType(value);
+    }
+
+    // Parse jsonPropertyRename
+    if (baseObj.has("jsonPropertyRename") && !baseObj.isNull("jsonPropertyRename")) {
+      final TestJsonPropertyRenameType value = TestJsonPropertyRenameTypeParser.parse(baseObj.getObject("jsonPropertyRename"));
+      config.setJsonPropertyRename(value);
     }
   }
 }


### PR DESCRIPTION
Generator and validator now treat `@JsonProperty("foo")` on a field as the canonical wire key and accessor stem, so `@JsonProperty("id")` private int assessmentAreaId reads from "id" in JSON and binds to setId(...) instead of setAssessmentAreaId(...). Without the annotation, behaviour reduces to the field name as before.