### PR TITLE
Smart subtype walk

### DIFF
--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/ParserGenerator.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/ParserGenerator.java
@@ -106,6 +106,7 @@ public class ParserGenerator {
       final TypeAnalyzer analyzer = new TypeAnalyzer(classFinder, logger);
       analyzer.setCustomParserTypes(customParserTypes);
       final Set<ClassName> classNames = analyzer.analyzeClass(targetClass.getName());
+      final Set<Class<?>> polymorphicallyReachedTypes = analyzer.getPolymorphicallyReachedTypes();
 
       // Filter out types that have custom parsers (this is now redundant since
       // TypeAnalyzer handles it)
@@ -116,7 +117,8 @@ public class ParserGenerator {
 
       // Create a parser writer and generate all parsers
       // Pass the generator name and details (version + hash) to the writer
-      final ParserWriter parserWriter = new ParserWriter(outputDir, parserPackage, generatorName, generatorDetails, classFinder, logger);
+      final ParserWriter parserWriter = new ParserWriter(outputDir, parserPackage, generatorName, generatorDetails, classFinder, logger,
+          polymorphicallyReachedTypes);
 
       parserWriter.generateParsers(classFinder, filteredClassNames);
 

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/analyzer/TypeAnalyzer.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/analyzer/TypeAnalyzer.java
@@ -39,6 +39,7 @@ public class TypeAnalyzer {
   private final Set<Class<?>> processedTypes;
   private final Set<String> skippedTypes;
   private final Set<ClassName> discoveredTypes;
+  private final Set<Class<?>> polymorphicallyReachedTypes;
   private final Set<String> printedTypes = new HashSet<>();
   private final Set<String> customParserTypes = new HashSet<>();
   private final ClassFinder classFinder;
@@ -80,6 +81,7 @@ public class TypeAnalyzer {
     processedTypes = new HashSet<>();
     skippedTypes = new HashSet<>();
     discoveredTypes = new TreeSet<>(Comparator.comparing(ClassName::toString));
+    polymorphicallyReachedTypes = new HashSet<>();
   }
 
   /**
@@ -102,6 +104,7 @@ public class TypeAnalyzer {
       skippedTypes.clear();
       discoveredTypes.clear();
       printedTypes.clear();
+      polymorphicallyReachedTypes.clear();
 
       analyzeTypeAndSubtypes(rootClass);
 
@@ -116,56 +119,83 @@ public class TypeAnalyzer {
     }
   }
 
+  /**
+   * Returns the polymorphic base types that were reached directly (as a field
+   * type or type argument) during the most recent analysis. Such types need a
+   * polymorphic dispatch parser; polymorphic bases reached only via a concrete
+   * subtype's superclass walk are absent from this set and should be emitted as
+   * standard parsers (so the concrete subtype can still parse its inherited
+   * fields without forcing sibling subtypes to be generated).
+   */
+  public Set<Class<?>> getPolymorphicallyReachedTypes() {
+    return polymorphicallyReachedTypes;
+  }
+
   private void analyzeTypeAndSubtypes(final Class<?> type) {
+    analyzeTypeAndSubtypes(type, true);
+  }
+
+  private void analyzeTypeAndSubtypes(final Class<?> type, final boolean reachedDirectly) {
     if (!shouldAnalyzeType(type)) {
       return;
     }
 
-    if (!processedTypes.add(type)) {
-      return; // Already processed
+    final boolean polymorphic = isPolymorphicBase(type);
+    final boolean firstVisit = processedTypes.add(type);
+    final boolean newPolymorphicReach = polymorphic && reachedDirectly && polymorphicallyReachedTypes.add(type);
+
+    if (!firstVisit && !newPolymorphicReach) {
+      return; // Already processed and no new direct reach to expand on
     }
 
-    // Print the class hierarchy if we haven't seen this type before
-    if (!printedTypes.contains(type.getName())) {
-      printClassHierarchy(type);
-      printedTypes.add(type.getName());
+    if (firstVisit) {
+      // Print the class hierarchy if we haven't seen this type before
+      if (!printedTypes.contains(type.getName())) {
+        printClassHierarchy(type);
+        printedTypes.add(type.getName());
+      }
+
+      // If this type has a custom parser, skip adding it for generation
+      // but continue analyzing its fields and subtypes
+      if (!hasCustomParser(type)) {
+        addTypeForGeneration(type);
+      } else {
+        logger.info("Skipping parser generation for " + type.getName() + " (has custom parser)");
+      }
+
+      // Walk superclasses, but mark them as not-directly-reached so a polymorphic
+      // base discovered only via a concrete subtype's superclass chain does not
+      // expand into its sibling subtypes.
+      final Class<?> superclass = type.getSuperclass();
+      if (superclass != null && superclass != Object.class) {
+        analyzeTypeAndSubtypes(superclass, false);
+      }
+
+      // Always analyze fields, even for types with custom parsers
+      // This ensures we discover all types that might need parsers
+      for (final Field field : ConstructorAnalyzer.getParseableFields(type)) {
+        try {
+          analyzeField(field);
+        } catch (final TypeNotPresentException e) {
+          skippedTypes.add(e.typeName());
+        }
+      }
     }
 
-    // If this type has a custom parser, skip adding it for generation
-    // but continue analyzing its fields and subtypes
-    if (!hasCustomParser(type)) {
-      addTypeForGeneration(type);
-    } else {
-      logger.info("Skipping parser generation for " + type.getName() + " (has custom parser)");
-    }
-
-    // Find and process superclasses
-    final Class<?> superclass = type.getSuperclass();
-    if (superclass != null && superclass != Object.class) {
-      analyzeTypeAndSubtypes(superclass);
-    }
-
-    final JsonSubTypes subTypesAnnotation = type.getAnnotation(JsonSubTypes.class);
-    final JsonTypeInfo typeInfoAnnotation = type.getAnnotation(JsonTypeInfo.class); // Check presence of base annotation too
-
-    if (subTypesAnnotation != null && typeInfoAnnotation != null) { // Only process if both are present
+    // Only expand @JsonSubTypes when the polymorphic base was reached directly.
+    if (newPolymorphicReach) {
+      final JsonSubTypes subTypesAnnotation = type.getAnnotation(JsonSubTypes.class);
       logger.info("Found @JsonSubTypes on: " + type.getName() + ", analyzing listed subtypes...");
       for (final JsonSubTypes.Type subType : subTypesAnnotation.value()) {
         final Class<?> subTypeValue = subType.value();
         logger.info("  - Analyzing subtype: " + subTypeValue.getName());
-        analyzeTypeAndSubtypes(subTypeValue); // Recursive call for the subtype
+        analyzeTypeAndSubtypes(subTypeValue, true);
       }
     }
+  }
 
-    // Always analyze fields, even for types with custom parsers
-    // This ensures we discover all types that might need parsers
-    for (final Field field : ConstructorAnalyzer.getParseableFields(type)) {
-      try {
-        analyzeField(field);
-      } catch (final TypeNotPresentException e) {
-        skippedTypes.add(e.typeName());
-      }
-    }
+  private boolean isPolymorphicBase(final Class<?> type) {
+    return type.isAnnotationPresent(JsonSubTypes.class) && type.isAnnotationPresent(JsonTypeInfo.class);
   }
 
   private void analyzeField(final Field field) {

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/analyzer/TypeAnalyzer.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/analyzer/TypeAnalyzer.java
@@ -106,7 +106,7 @@ public class TypeAnalyzer {
       printedTypes.clear();
       polymorphicallyReachedTypes.clear();
 
-      analyzeTypeAndSubtypes(rootClass);
+      analyzeTypeAndSubtypes(rootClass, true);
 
       if (!skippedTypes.isEmpty()) {
         logger.info("Warning: The following types were not found and skipped:");
@@ -120,19 +120,13 @@ public class TypeAnalyzer {
   }
 
   /**
-   * Returns the polymorphic base types that were reached directly (as a field
-   * type or type argument) during the most recent analysis. Such types need a
-   * polymorphic dispatch parser; polymorphic bases reached only via a concrete
-   * subtype's superclass walk are absent from this set and should be emitted as
-   * standard parsers (so the concrete subtype can still parse its inherited
-   * fields without forcing sibling subtypes to be generated).
+   * Polymorphic bases reached directly (as a field type or type argument) in
+   * the most recent analysis. The generator emits a discriminator switch for
+   * these; bases reached only via a concrete subtype's superclass chain are
+   * absent and get a standard parse method instead.
    */
   public Set<Class<?>> getPolymorphicallyReachedTypes() {
     return polymorphicallyReachedTypes;
-  }
-
-  private void analyzeTypeAndSubtypes(final Class<?> type) {
-    analyzeTypeAndSubtypes(type, true);
   }
 
   private void analyzeTypeAndSubtypes(final Class<?> type, final boolean reachedDirectly) {
@@ -145,34 +139,28 @@ public class TypeAnalyzer {
     final boolean newPolymorphicReach = polymorphic && reachedDirectly && polymorphicallyReachedTypes.add(type);
 
     if (!firstVisit && !newPolymorphicReach) {
-      return; // Already processed and no new direct reach to expand on
+      return;
     }
 
     if (firstVisit) {
-      // Print the class hierarchy if we haven't seen this type before
       if (!printedTypes.contains(type.getName())) {
         printClassHierarchy(type);
         printedTypes.add(type.getName());
       }
 
-      // If this type has a custom parser, skip adding it for generation
-      // but continue analyzing its fields and subtypes
       if (!hasCustomParser(type)) {
         addTypeForGeneration(type);
       } else {
         logger.info("Skipping parser generation for " + type.getName() + " (has custom parser)");
       }
 
-      // Walk superclasses, but mark them as not-directly-reached so a polymorphic
-      // base discovered only via a concrete subtype's superclass chain does not
-      // expand into its sibling subtypes.
+      // Superclasses are not "directly reached" - if the superclass is a
+      // polymorphic base, sibling subtypes stay unwalked.
       final Class<?> superclass = type.getSuperclass();
       if (superclass != null && superclass != Object.class) {
         analyzeTypeAndSubtypes(superclass, false);
       }
 
-      // Always analyze fields, even for types with custom parsers
-      // This ensures we discover all types that might need parsers
       for (final Field field : ConstructorAnalyzer.getParseableFields(type)) {
         try {
           analyzeField(field);
@@ -244,12 +232,12 @@ public class TypeAnalyzer {
       if (isUnsupportedType(classType)) {
         throw new UnsupportedTypeException(classType.getName(), "type parameter/element", Object.class);
       }
-      analyzeTypeAndSubtypes(classType);
+      analyzeTypeAndSubtypes(classType, true);
     } else if (type instanceof ParameterizedType) {
       final ParameterizedType paramType = (ParameterizedType) type;
       // Analyze the raw type
       if (paramType.getRawType() instanceof Class<?>) {
-        analyzeTypeAndSubtypes((Class<?>) paramType.getRawType());
+        analyzeTypeAndSubtypes((Class<?>) paramType.getRawType(), true);
       }
       // Analyze all type arguments recursively
       for (final Type typeArg : paramType.getActualTypeArguments()) {

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriter.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriter.java
@@ -1,7 +1,6 @@
 package nl.aerius.codegen.generator;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Set;
 
 import com.palantir.javapoet.ClassName;
@@ -22,11 +21,6 @@ public class ParserWriter {
   private final ClassFinder classFinder;
   private final Logger logger;
   private final Set<Class<?>> polymorphicallyReachedTypes;
-
-  public ParserWriter(final String outputDir, final String parserPackage, final String generatorName,
-      final String generatorDetails, final ClassFinder classFinder, final Logger logger) {
-    this(outputDir, parserPackage, generatorName, generatorDetails, classFinder, logger, Collections.emptySet());
-  }
 
   public ParserWriter(final String outputDir, final String parserPackage, final String generatorName,
       final String generatorDetails, final ClassFinder classFinder, final Logger logger,

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriter.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriter.java
@@ -1,6 +1,7 @@
 package nl.aerius.codegen.generator;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Set;
 
 import com.palantir.javapoet.ClassName;
@@ -20,15 +21,23 @@ public class ParserWriter {
   private final String generatorDetails;
   private final ClassFinder classFinder;
   private final Logger logger;
+  private final Set<Class<?>> polymorphicallyReachedTypes;
 
   public ParserWriter(final String outputDir, final String parserPackage, final String generatorName,
       final String generatorDetails, final ClassFinder classFinder, final Logger logger) {
+    this(outputDir, parserPackage, generatorName, generatorDetails, classFinder, logger, Collections.emptySet());
+  }
+
+  public ParserWriter(final String outputDir, final String parserPackage, final String generatorName,
+      final String generatorDetails, final ClassFinder classFinder, final Logger logger,
+      final Set<Class<?>> polymorphicallyReachedTypes) {
     this.outputDir = outputDir;
     this.parserPackage = parserPackage;
     this.generatorName = generatorName;
     this.generatorDetails = generatorDetails;
     this.classFinder = classFinder;
     this.logger = logger;
+    this.polymorphicallyReachedTypes = polymorphicallyReachedTypes;
   }
 
   /**
@@ -43,8 +52,10 @@ public class ParserWriter {
     // Create the parser type specification, passing both name and details
     final TypeSpec.Builder typeSpec = ParserWriterUtils.createParserTypeSpec(parserClassName, generatorName, generatorDetails);
 
+    final boolean usePolymorphicDispatch = polymorphicallyReachedTypes.contains(targetClass);
+
     // Add parser methods
-    ParserWriterUtils.generateParserForFields(typeSpec, targetClass, parserPackage, classFinder);
+    ParserWriterUtils.generateParserForFields(typeSpec, targetClass, parserPackage, classFinder, usePolymorphicDispatch);
 
     // Write to file
     ParserWriterUtils.writeParserToFile(outputDir, parserPackage, typeSpec.build(), parserClassName, logger);

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriterUtils.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriterUtils.java
@@ -126,6 +126,20 @@ public final class ParserWriterUtils {
    */
   public static void generateParserForFields(final TypeSpec.Builder typeSpec, final Class<?> targetClass, final String parserPackage,
       final ClassFinder classFinder) {
+    generateParserForFields(typeSpec, targetClass, parserPackage, classFinder,
+        hasJsonTypeInfoWithNameDiscriminator(targetClass));
+  }
+
+  /**
+   * Main entry point for generating a parser class with explicit polymorphic
+   * dispatch control. When {@code usePolymorphicDispatch} is false on a class
+   * that has @JsonTypeInfo/@JsonSubTypes, a standard parse method is emitted
+   * instead of the discriminator switch - used when the analyzer determined
+   * the type is reachable only via a concrete subtype, so sibling subtype
+   * parsers are not generated and a polymorphic switch would not compile.
+   */
+  public static void generateParserForFields(final TypeSpec.Builder typeSpec, final Class<?> targetClass, final String parserPackage,
+      final ClassFinder classFinder, final boolean usePolymorphicDispatch) {
     typeSpec.addMethod(createStringParseMethod(targetClass));
 
     // Check if this class should use constructor-based parsing
@@ -136,7 +150,7 @@ public final class ParserWriterUtils {
       typeSpec.addMethod(createConstructorBasedParseMethod(targetClass, parserPackage, constructorInfo.get()));
     } else {
       // Setter-based: existing approach
-      addSetterBasedParseMethods(typeSpec, targetClass, parserPackage);
+      addSetterBasedParseMethods(typeSpec, targetClass, parserPackage, usePolymorphicDispatch);
     }
   }
 
@@ -144,8 +158,8 @@ public final class ParserWriterUtils {
    * Adds setter-based parse methods to the type specification.
    */
   private static void addSetterBasedParseMethods(final TypeSpec.Builder typeSpec, final Class<?> targetClass,
-      final String parserPackage) {
-    if (hasJsonTypeInfoWithNameDiscriminator(targetClass)) {
+      final String parserPackage, final boolean usePolymorphicDispatch) {
+    if (usePolymorphicDispatch) {
       typeSpec.addMethod(createPolymorphicObjectParseMethod(targetClass, parserPackage));
     } else {
       typeSpec.addMethod(createStandardObjectParseMethod(targetClass, parserPackage));

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriterUtils.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriterUtils.java
@@ -119,24 +119,12 @@ public final class ParserWriterUtils {
   }
 
   /**
-   * Main entry point for generating a parser class.
-   * Creates both parse(String) and parse(JSONObjectHandle) methods.
-   * For constructor-based types (no setters), generates constructor-based parse method.
-   * @param classFinder
-   */
-  public static void generateParserForFields(final TypeSpec.Builder typeSpec, final Class<?> targetClass, final String parserPackage,
-      final ClassFinder classFinder) {
-    generateParserForFields(typeSpec, targetClass, parserPackage, classFinder,
-        hasJsonTypeInfoWithNameDiscriminator(targetClass));
-  }
-
-  /**
-   * Main entry point for generating a parser class with explicit polymorphic
-   * dispatch control. When {@code usePolymorphicDispatch} is false on a class
-   * that has @JsonTypeInfo/@JsonSubTypes, a standard parse method is emitted
-   * instead of the discriminator switch - used when the analyzer determined
-   * the type is reachable only via a concrete subtype, so sibling subtype
-   * parsers are not generated and a polymorphic switch would not compile.
+   * Main entry point for generating a parser class. When
+   * {@code usePolymorphicDispatch} is false on a class that has
+   * {@code @JsonTypeInfo}/{@code @JsonSubTypes}, a standard parse method is
+   * emitted instead of the discriminator switch - the caller has determined
+   * the type is reached only via a concrete subtype and the sibling subtype
+   * parsers are not generated.
    */
   public static void generateParserForFields(final TypeSpec.Builder typeSpec, final Class<?> targetClass, final String parserPackage,
       final ClassFinder classFinder, final boolean usePolymorphicDispatch) {

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/analyzer/TypeAnalyzerTest.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/analyzer/TypeAnalyzerTest.java
@@ -12,6 +12,10 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.palantir.javapoet.ClassName;
 
 import nl.aerius.codegen.util.ClassFinder;
@@ -48,6 +52,32 @@ class TypeAnalyzerTest {
 
     assertFalse(types.contains(ClassName.get("nl.aerius.codegen.analyzer", "TypeAnalyzerTest_CustomParserType")));
     assertTrue(types.contains(ClassName.get("nl.aerius.codegen.analyzer", "TypeAnalyzerTest_CustomParserTestClass")));
+  }
+
+  @Test
+  void abstractBaseReachedViaConcreteSubtypeOnlyDoesNotExpandSiblings() {
+    final Set<ClassName> types = analyzer.analyzeClass(ConcreteOnlyRootClass.class.getName());
+
+    assertTrue(types.contains(ClassName.get("nl.aerius.codegen.analyzer", "TypeAnalyzerTest_ConcreteOnlyRootClass")));
+    assertTrue(types.contains(ClassName.get("nl.aerius.codegen.analyzer", "TypeAnalyzerTest_PolySubAlpha")));
+    assertTrue(types.contains(ClassName.get("nl.aerius.codegen.analyzer", "TypeAnalyzerTest_PolyAbstractBase")),
+        "Abstract base should still be discovered (its parse(handle, config) is invoked by the subtype parser)");
+    assertFalse(types.contains(ClassName.get("nl.aerius.codegen.analyzer", "TypeAnalyzerTest_PolySubBeta")),
+        "Sibling subtype must be skipped when the base is only reached via a concrete subtype");
+    assertFalse(analyzer.getPolymorphicallyReachedTypes().contains(PolyAbstractBase.class),
+        "Base reached only via concrete subtype's superclass walk should NOT be flagged for polymorphic dispatch");
+  }
+
+  @Test
+  void abstractBaseReachedDirectlyExpandsAllSubtypes() {
+    final Set<ClassName> types = analyzer.analyzeClass(AbstractFieldRootClass.class.getName());
+
+    assertTrue(types.contains(ClassName.get("nl.aerius.codegen.analyzer", "TypeAnalyzerTest_PolyAbstractBase")));
+    assertTrue(types.contains(ClassName.get("nl.aerius.codegen.analyzer", "TypeAnalyzerTest_PolySubAlpha")));
+    assertTrue(types.contains(ClassName.get("nl.aerius.codegen.analyzer", "TypeAnalyzerTest_PolySubBeta")),
+        "Abstract field type must walk all subtypes for the discriminator switch");
+    assertTrue(analyzer.getPolymorphicallyReachedTypes().contains(PolyAbstractBase.class),
+        "Direct abstract reach must flag the base for polymorphic dispatch generation");
   }
 
   @Test
@@ -98,5 +128,73 @@ class TypeAnalyzerTest {
 
   private static class ComplexNestedTestClass {
     private Map<TestEnum, Map<Integer, Map<Integer, String>>> complexNestedMap;
+  }
+
+  // Polymorphic hierarchy used by reach-tracking tests.
+  @JsonTypeInfo(use = Id.NAME, property = "_type")
+  @JsonSubTypes({
+      @Type(value = PolySubAlpha.class, name = "alpha"),
+      @Type(value = PolySubBeta.class, name = "beta")
+  })
+  private static abstract class PolyAbstractBase {
+    private String baseLabel;
+
+    public String getBaseLabel() {
+      return baseLabel;
+    }
+
+    public void setBaseLabel(final String baseLabel) {
+      this.baseLabel = baseLabel;
+    }
+  }
+
+  private static class PolySubAlpha extends PolyAbstractBase {
+    private int alphaValue;
+
+    public int getAlphaValue() {
+      return alphaValue;
+    }
+
+    public void setAlphaValue(final int alphaValue) {
+      this.alphaValue = alphaValue;
+    }
+  }
+
+  private static class PolySubBeta extends PolyAbstractBase {
+    private boolean betaFlag;
+
+    public boolean isBetaFlag() {
+      return betaFlag;
+    }
+
+    public void setBetaFlag(final boolean betaFlag) {
+      this.betaFlag = betaFlag;
+    }
+  }
+
+  // Field declares the concrete subtype - base is reached only via its superclass chain.
+  private static class ConcreteOnlyRootClass {
+    private PolySubAlpha onlyConcrete;
+
+    public PolySubAlpha getOnlyConcrete() {
+      return onlyConcrete;
+    }
+
+    public void setOnlyConcrete(final PolySubAlpha onlyConcrete) {
+      this.onlyConcrete = onlyConcrete;
+    }
+  }
+
+  // Field declares the abstract base - every subtype must be reachable.
+  private static class AbstractFieldRootClass {
+    private PolyAbstractBase polymorphic;
+
+    public PolyAbstractBase getPolymorphic() {
+      return polymorphic;
+    }
+
+    public void setPolymorphic(final PolyAbstractBase polymorphic) {
+      this.polymorphic = polymorphic;
+    }
   }
 }

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/analyzer/TypeAnalyzerTest.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/analyzer/TypeAnalyzerTest.java
@@ -58,26 +58,19 @@ class TypeAnalyzerTest {
   void abstractBaseReachedViaConcreteSubtypeOnlyDoesNotExpandSiblings() {
     final Set<ClassName> types = analyzer.analyzeClass(ConcreteOnlyRootClass.class.getName());
 
-    assertTrue(types.contains(ClassName.get("nl.aerius.codegen.analyzer", "TypeAnalyzerTest_ConcreteOnlyRootClass")));
     assertTrue(types.contains(ClassName.get("nl.aerius.codegen.analyzer", "TypeAnalyzerTest_PolySubAlpha")));
-    assertTrue(types.contains(ClassName.get("nl.aerius.codegen.analyzer", "TypeAnalyzerTest_PolyAbstractBase")),
-        "Abstract base should still be discovered (its parse(handle, config) is invoked by the subtype parser)");
-    assertFalse(types.contains(ClassName.get("nl.aerius.codegen.analyzer", "TypeAnalyzerTest_PolySubBeta")),
-        "Sibling subtype must be skipped when the base is only reached via a concrete subtype");
-    assertFalse(analyzer.getPolymorphicallyReachedTypes().contains(PolyAbstractBase.class),
-        "Base reached only via concrete subtype's superclass walk should NOT be flagged for polymorphic dispatch");
+    assertTrue(types.contains(ClassName.get("nl.aerius.codegen.analyzer", "TypeAnalyzerTest_PolyAbstractBase")));
+    assertFalse(types.contains(ClassName.get("nl.aerius.codegen.analyzer", "TypeAnalyzerTest_PolySubBeta")));
+    assertFalse(analyzer.getPolymorphicallyReachedTypes().contains(PolyAbstractBase.class));
   }
 
   @Test
   void abstractBaseReachedDirectlyExpandsAllSubtypes() {
     final Set<ClassName> types = analyzer.analyzeClass(AbstractFieldRootClass.class.getName());
 
-    assertTrue(types.contains(ClassName.get("nl.aerius.codegen.analyzer", "TypeAnalyzerTest_PolyAbstractBase")));
     assertTrue(types.contains(ClassName.get("nl.aerius.codegen.analyzer", "TypeAnalyzerTest_PolySubAlpha")));
-    assertTrue(types.contains(ClassName.get("nl.aerius.codegen.analyzer", "TypeAnalyzerTest_PolySubBeta")),
-        "Abstract field type must walk all subtypes for the discriminator switch");
-    assertTrue(analyzer.getPolymorphicallyReachedTypes().contains(PolyAbstractBase.class),
-        "Direct abstract reach must flag the base for polymorphic dispatch generation");
+    assertTrue(types.contains(ClassName.get("nl.aerius.codegen.analyzer", "TypeAnalyzerTest_PolySubBeta")));
+    assertTrue(analyzer.getPolymorphicallyReachedTypes().contains(PolyAbstractBase.class));
   }
 
   @Test
@@ -130,7 +123,6 @@ class TypeAnalyzerTest {
     private Map<TestEnum, Map<Integer, Map<Integer, String>>> complexNestedMap;
   }
 
-  // Polymorphic hierarchy used by reach-tracking tests.
   @JsonTypeInfo(use = Id.NAME, property = "_type")
   @JsonSubTypes({
       @Type(value = PolySubAlpha.class, name = "alpha"),
@@ -138,63 +130,21 @@ class TypeAnalyzerTest {
   })
   private static abstract class PolyAbstractBase {
     private String baseLabel;
-
-    public String getBaseLabel() {
-      return baseLabel;
-    }
-
-    public void setBaseLabel(final String baseLabel) {
-      this.baseLabel = baseLabel;
-    }
   }
 
   private static class PolySubAlpha extends PolyAbstractBase {
     private int alphaValue;
-
-    public int getAlphaValue() {
-      return alphaValue;
-    }
-
-    public void setAlphaValue(final int alphaValue) {
-      this.alphaValue = alphaValue;
-    }
   }
 
   private static class PolySubBeta extends PolyAbstractBase {
     private boolean betaFlag;
-
-    public boolean isBetaFlag() {
-      return betaFlag;
-    }
-
-    public void setBetaFlag(final boolean betaFlag) {
-      this.betaFlag = betaFlag;
-    }
   }
 
-  // Field declares the concrete subtype - base is reached only via its superclass chain.
   private static class ConcreteOnlyRootClass {
     private PolySubAlpha onlyConcrete;
-
-    public PolySubAlpha getOnlyConcrete() {
-      return onlyConcrete;
-    }
-
-    public void setOnlyConcrete(final PolySubAlpha onlyConcrete) {
-      this.onlyConcrete = onlyConcrete;
-    }
   }
 
-  // Field declares the abstract base - every subtype must be reachable.
   private static class AbstractFieldRootClass {
     private PolyAbstractBase polymorphic;
-
-    public PolyAbstractBase getPolymorphic() {
-      return polymorphic;
-    }
-
-    public void setPolymorphic(final PolyAbstractBase polymorphic) {
-      this.polymorphic = polymorphic;
-    }
   }
 }

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/GeneratedParserValidationTest.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/GeneratedParserValidationTest.java
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -65,5 +66,14 @@ class GeneratedParserValidationTest extends ParserGeneratorTestBase {
     });
   }
 
-  // Removed compareAllParsers method as logic moved to @TestFactory
+  @Test
+  void shouldSkipSiblingSubtypeWhenOnlyConcreteSubtypeIsReached() {
+    final Path siblingParser = outputDir.resolve("nl/aerius/codegen/test/generated/TestSinglePolySubYParser.java");
+    Assertions.assertFalse(Files.exists(siblingParser),
+        "TestSinglePolySubYParser should NOT be generated: nothing in the reachable type graph "
+            + "references TestSinglePolyBase abstractly, only TestSinglePolySubX is referenced. "
+            + "Generating a parser for TestSinglePolySubY would force callers to ship hand-written "
+            + "custom parsers for hierarchies that contain unsupported codegen patterns. "
+            + "Found unexpected file at: " + siblingParser);
+  }
 }

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/GeneratedParserValidationTest.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/GeneratedParserValidationTest.java
@@ -70,10 +70,6 @@ class GeneratedParserValidationTest extends ParserGeneratorTestBase {
   void shouldSkipSiblingSubtypeWhenOnlyConcreteSubtypeIsReached() {
     final Path siblingParser = outputDir.resolve("nl/aerius/codegen/test/generated/TestSinglePolySubYParser.java");
     Assertions.assertFalse(Files.exists(siblingParser),
-        "TestSinglePolySubYParser should NOT be generated: nothing in the reachable type graph "
-            + "references TestSinglePolyBase abstractly, only TestSinglePolySubX is referenced. "
-            + "Generating a parser for TestSinglePolySubY would force callers to ship hand-written "
-            + "custom parsers for hierarchies that contain unsupported codegen patterns. "
-            + "Found unexpected file at: " + siblingParser);
+        "Sibling subtype parser must not be generated when only the other concrete subtype is referenced: " + siblingParser);
   }
 }

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestConcreteSubtypeOnlyType.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestConcreteSubtypeOnlyType.java
@@ -1,0 +1,28 @@
+package nl.aerius.codegen.test.types;
+
+import nl.aerius.codegen.test.types.polymorphic.TestSinglePolySubX;
+
+/**
+ * Wires only a concrete subtype of a polymorphic hierarchy. The hierarchy's
+ * abstract base (TestSinglePolyBase) is reachable via the subtype's superclass
+ * chain, but no field is declared as the base itself - so the generator should
+ * skip sibling subtype parsers (TestSinglePolySubY) and emit a plain parser
+ * for the abstract base rather than a polymorphic discriminator switch.
+ */
+public class TestConcreteSubtypeOnlyType {
+  private TestSinglePolySubX onlySubtype;
+
+  public TestSinglePolySubX getOnlySubtype() {
+    return onlySubtype;
+  }
+
+  public void setOnlySubtype(TestSinglePolySubX onlySubtype) {
+    this.onlySubtype = onlySubtype;
+  }
+
+  public static TestConcreteSubtypeOnlyType createFullObject() {
+    TestConcreteSubtypeOnlyType obj = new TestConcreteSubtypeOnlyType();
+    obj.setOnlySubtype(new TestSinglePolySubX("labelX", 99));
+    return obj;
+  }
+}

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestConcreteSubtypeOnlyType.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestConcreteSubtypeOnlyType.java
@@ -3,11 +3,8 @@ package nl.aerius.codegen.test.types;
 import nl.aerius.codegen.test.types.polymorphic.TestSinglePolySubX;
 
 /**
- * Wires only a concrete subtype of a polymorphic hierarchy. The hierarchy's
- * abstract base (TestSinglePolyBase) is reachable via the subtype's superclass
- * chain, but no field is declared as the base itself - so the generator should
- * skip sibling subtype parsers (TestSinglePolySubY) and emit a plain parser
- * for the abstract base rather than a polymorphic discriminator switch.
+ * References only one concrete subtype of a polymorphic hierarchy. The
+ * sibling subtype (TestSinglePolySubY) must not get a generated parser.
  */
 public class TestConcreteSubtypeOnlyType {
   private TestSinglePolySubX onlySubtype;

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestRootObjectType.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/TestRootObjectType.java
@@ -21,6 +21,7 @@ public class TestRootObjectType {
   private TestNestedMapType nestedMapType;
 
   private TestPolyBase testPolyBase;
+  private TestConcreteSubtypeOnlyType concreteSubtypeOnly;
   private TestPrimitiveArrayType primitiveArrays;
   private TestConstructorBasedType constructorBased;
   private TestConstructorWithGenericsType constructorWithGenerics;
@@ -131,6 +132,14 @@ public class TestRootObjectType {
     this.testPolyBase = testPolyBase;
   }
 
+  public TestConcreteSubtypeOnlyType getConcreteSubtypeOnly() {
+    return concreteSubtypeOnly;
+  }
+
+  public void setConcreteSubtypeOnly(TestConcreteSubtypeOnlyType concreteSubtypeOnly) {
+    this.concreteSubtypeOnly = concreteSubtypeOnly;
+  }
+
   public TestPrimitiveArrayType getPrimitiveArrays() {
     return primitiveArrays;
   }
@@ -186,6 +195,7 @@ public class TestRootObjectType {
     obj.setConcreteType(ConcreteType.createFullObject());
     obj.setNestedMapType(TestNestedMapType.createFullObject());
     obj.setTestPolyBase(new TestPolySubA("BaseValueA", 123));
+    obj.setConcreteSubtypeOnly(TestConcreteSubtypeOnlyType.createFullObject());
     obj.setPrimitiveArrays(TestPrimitiveArrayType.createFullObject());
     obj.setConstructorBased(TestConstructorBasedType.createFullObject());
     obj.setConstructorWithGenerics(TestConstructorWithGenericsType.createFullObject());
@@ -234,6 +244,7 @@ public class TestRootObjectType {
     obj.setConcreteType(null);
     obj.setNestedMapType(null);
     obj.setTestPolyBase(null);
+    obj.setConcreteSubtypeOnly(null);
     obj.setPrimitiveArrays(null);
     return obj;
   }

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/polymorphic/TestSinglePolyBase.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/polymorphic/TestSinglePolyBase.java
@@ -1,0 +1,48 @@
+package nl.aerius.codegen.test.types.polymorphic;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+
+@JsonTypeInfo(use = Id.NAME, property = "_type")
+@JsonSubTypes({
+    @Type(value = TestSinglePolySubX.class, name = "TypeX"),
+    @Type(value = TestSinglePolySubY.class, name = "TypeY")
+})
+public abstract class TestSinglePolyBase implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private String baseLabel;
+
+  protected TestSinglePolyBase() {}
+
+  protected TestSinglePolyBase(String baseLabel) {
+    this.baseLabel = baseLabel;
+  }
+
+  public String getBaseLabel() {
+    return baseLabel;
+  }
+
+  public void setBaseLabel(String baseLabel) {
+    this.baseLabel = baseLabel;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof TestSinglePolyBase)) return false;
+    TestSinglePolyBase that = (TestSinglePolyBase) o;
+    return Objects.equals(getBaseLabel(), that.getBaseLabel());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getBaseLabel());
+  }
+}

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/polymorphic/TestSinglePolySubX.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/polymorphic/TestSinglePolySubX.java
@@ -1,0 +1,41 @@
+package nl.aerius.codegen.test.types.polymorphic;
+
+import java.util.Objects;
+
+public class TestSinglePolySubX extends TestSinglePolyBase {
+
+  private static final long serialVersionUID = 1L;
+
+  private int valueX;
+
+  public TestSinglePolySubX() {
+    super();
+  }
+
+  public TestSinglePolySubX(String baseLabel, int valueX) {
+    super(baseLabel);
+    this.valueX = valueX;
+  }
+
+  public int getValueX() {
+    return valueX;
+  }
+
+  public void setValueX(int valueX) {
+    this.valueX = valueX;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof TestSinglePolySubX)) return false;
+    if (!super.equals(o)) return false;
+    TestSinglePolySubX that = (TestSinglePolySubX) o;
+    return getValueX() == that.getValueX();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), getValueX());
+  }
+}

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/polymorphic/TestSinglePolySubY.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/types/polymorphic/TestSinglePolySubY.java
@@ -1,0 +1,41 @@
+package nl.aerius.codegen.test.types.polymorphic;
+
+import java.util.Objects;
+
+public class TestSinglePolySubY extends TestSinglePolyBase {
+
+  private static final long serialVersionUID = 1L;
+
+  private boolean flagY;
+
+  public TestSinglePolySubY() {
+    super();
+  }
+
+  public TestSinglePolySubY(String baseLabel, boolean flagY) {
+    super(baseLabel);
+    this.flagY = flagY;
+  }
+
+  public boolean isFlagY() {
+    return flagY;
+  }
+
+  public void setFlagY(boolean flagY) {
+    this.flagY = flagY;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof TestSinglePolySubY)) return false;
+    if (!super.equals(o)) return false;
+    TestSinglePolySubY that = (TestSinglePolySubY) o;
+    return isFlagY() == that.isFlagY();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), isFlagY());
+  }
+}

--- a/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestConcreteSubtypeOnlyTypeParser.java
+++ b/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestConcreteSubtypeOnlyTypeParser.java
@@ -1,0 +1,42 @@
+package nl.aerius.codegen.test.generated;
+
+import javax.annotation.processing.Generated;
+
+import nl.aerius.codegen.test.types.TestConcreteSubtypeOnlyType;
+import nl.aerius.codegen.test.types.polymorphic.TestSinglePolySubX;
+import nl.aerius.json.JSONObjectHandle;
+
+@Generated(value = "nl.aerius.codegen.ParserGenerator", date = "GENERATION_TIMESTAMP")
+public class TestConcreteSubtypeOnlyTypeParser {
+
+  public static TestConcreteSubtypeOnlyType parse(final String jsonText) {
+    if (jsonText == null) {
+      return null;
+    }
+
+    return parse(JSONObjectHandle.fromText(jsonText));
+  }
+
+  public static TestConcreteSubtypeOnlyType parse(final JSONObjectHandle baseObj) {
+    if (baseObj == null) {
+      return null;
+    }
+
+    final TestConcreteSubtypeOnlyType config = new TestConcreteSubtypeOnlyType();
+    parse(baseObj, config);
+    return config;
+  }
+
+  public static void parse(final JSONObjectHandle baseObj,
+      final TestConcreteSubtypeOnlyType config) {
+    if (baseObj == null || config == null) {
+      return;
+    }
+
+    // Parse onlySubtype
+    if (baseObj.has("onlySubtype") && !baseObj.isNull("onlySubtype")) {
+      final TestSinglePolySubX value = TestSinglePolySubXParser.parse(baseObj.getObject("onlySubtype"));
+      config.setOnlySubtype(value);
+    }
+  }
+}

--- a/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestRootObjectTypeParser.java
+++ b/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestRootObjectTypeParser.java
@@ -6,6 +6,7 @@ import nl.aerius.codegen.test.custom.TestCustomParserTypeParser;
 import nl.aerius.codegen.test.types.ConcreteType;
 import nl.aerius.codegen.test.types.TestAdvancedMapType;
 import nl.aerius.codegen.test.types.TestComplexCollectionType;
+import nl.aerius.codegen.test.types.TestConcreteSubtypeOnlyType;
 import nl.aerius.codegen.test.types.TestConstructorBasedType;
 import nl.aerius.codegen.test.types.TestConstructorWithGenericsType;
 import nl.aerius.codegen.test.types.TestConstructorWithIgnoredFieldType;
@@ -122,6 +123,12 @@ public class TestRootObjectTypeParser {
     if (baseObj.has("testPolyBase") && !baseObj.isNull("testPolyBase")) {
       final TestPolyBase value = TestPolyBaseParser.parse(baseObj.getObject("testPolyBase"));
       config.setTestPolyBase(value);
+    }
+
+    // Parse concreteSubtypeOnly
+    if (baseObj.has("concreteSubtypeOnly") && !baseObj.isNull("concreteSubtypeOnly")) {
+      final TestConcreteSubtypeOnlyType value = TestConcreteSubtypeOnlyTypeParser.parse(baseObj.getObject("concreteSubtypeOnly"));
+      config.setConcreteSubtypeOnly(value);
     }
 
     // Parse primitiveArrays

--- a/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestSinglePolyBaseParser.java
+++ b/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestSinglePolyBaseParser.java
@@ -1,0 +1,38 @@
+package nl.aerius.codegen.test.generated;
+
+import javax.annotation.processing.Generated;
+
+import nl.aerius.codegen.test.types.polymorphic.TestSinglePolyBase;
+import nl.aerius.json.JSONObjectHandle;
+
+@Generated(value = "nl.aerius.codegen.ParserGenerator", date = "GENERATION_TIMESTAMP")
+public class TestSinglePolyBaseParser {
+
+  public static TestSinglePolyBase parse(final String jsonText) {
+    if (jsonText == null) {
+      return null;
+    }
+
+    return parse(JSONObjectHandle.fromText(jsonText));
+  }
+
+  public static TestSinglePolyBase parse(final JSONObjectHandle baseObj) {
+    if (baseObj == null) {
+      return null;
+    }
+
+    throw new UnsupportedOperationException("Cannot directly instantiate abstract class or interface " + TestSinglePolyBase.class.getName() + ". Use @JsonTypeInfo or a custom parser.");
+  }
+
+  public static void parse(final JSONObjectHandle baseObj, final TestSinglePolyBase config) {
+    if (baseObj == null || config == null) {
+      return;
+    }
+
+    // Parse baseLabel
+    if (baseObj.has("baseLabel") && !baseObj.isNull("baseLabel")) {
+      final String value = baseObj.getString("baseLabel");
+      config.setBaseLabel(value);
+    }
+  }
+}

--- a/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestSinglePolySubXParser.java
+++ b/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestSinglePolySubXParser.java
@@ -1,0 +1,43 @@
+package nl.aerius.codegen.test.generated;
+
+import javax.annotation.processing.Generated;
+
+import nl.aerius.codegen.test.types.polymorphic.TestSinglePolySubX;
+import nl.aerius.json.JSONObjectHandle;
+
+@Generated(value = "nl.aerius.codegen.ParserGenerator", date = "GENERATION_TIMESTAMP")
+public class TestSinglePolySubXParser {
+
+  public static TestSinglePolySubX parse(final String jsonText) {
+    if (jsonText == null) {
+      return null;
+    }
+
+    return parse(JSONObjectHandle.fromText(jsonText));
+  }
+
+  public static TestSinglePolySubX parse(final JSONObjectHandle baseObj) {
+    if (baseObj == null) {
+      return null;
+    }
+
+    final TestSinglePolySubX config = new TestSinglePolySubX();
+    parse(baseObj, config);
+    return config;
+  }
+
+  public static void parse(final JSONObjectHandle baseObj, final TestSinglePolySubX config) {
+    if (baseObj == null || config == null) {
+      return;
+    }
+
+    // Parse fields from parent class (TestSinglePolyBase)
+    TestSinglePolyBaseParser.parse(baseObj, config);
+
+    // Parse valueX
+    if (baseObj.has("valueX")) {
+      final int value = baseObj.getInteger("valueX");
+      config.setValueX(value);
+    }
+  }
+}


### PR DESCRIPTION
If we only use one concrete subtype, then we no longer make the type analyzer produce parsers for all siblings

(in calculator, we made it produce subtypes for Point, which made the generator find the supertype Geometry, which then referenced children and siblings of Point -- LineString and Polygon -- which we didn't actually reference anywhere in the original root class hierarchy and therefore is safe to not produce parsers for)