### PR TITLE
Tolerate missing non-primitive fields in constructor-based parsing

### DIFF
--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriterUtils.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriterUtils.java
@@ -88,7 +88,7 @@ public final class ParserWriterUtils {
   public static void initParsers(final ClassFinder classFinder, final Logger logger) {
     enumFieldParser = new EnumFieldParser(classFinder, logger);
     collectionFieldParser = new CollectionFieldParser(classFinder, logger);
-    mapFieldParser = new MapFieldParser(logger);
+    mapFieldParser = new MapFieldParser(classFinder, logger);
 
     PARSERS = new TypeParser[] {
         SIMPLE_FIELD_PARSER,

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriterUtils.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/ParserWriterUtils.java
@@ -21,6 +21,7 @@ import com.palantir.javapoet.ClassName;
 import com.palantir.javapoet.CodeBlock;
 import com.palantir.javapoet.JavaFile;
 import com.palantir.javapoet.MethodSpec;
+import com.palantir.javapoet.TypeName;
 import com.palantir.javapoet.TypeSpec;
 
 import nl.aerius.codegen.analyzer.ConstructorAnalyzer;
@@ -402,38 +403,69 @@ public final class ParserWriterUtils {
 
   /**
    * Generates parsing code for a single field in a constructor-based parser.
+   *
+   * <p>Primitive fields are required: Jackson always serializes them, so a missing primitive in the
+   * JSON indicates a malformed payload and we throw. Non-primitive fields tolerate missing or null
+   * entries because Jackson omits null fields by default - the resulting constructor arg defaults
+   * to {@code null} and is only populated when the JSON has a non-null value. This mirrors the
+   * setter-based path, which already silently skips missing fields via
+   * {@link ParserCommonUtils#createFieldExistsCheck}.
    */
   private static String generateFieldParsingCode(final MethodSpec.Builder methodBuilder, final Field field,
       final String parserPackage) {
     methodBuilder.addCode("\n");
     methodBuilder.addComment("Parse $L", field.getName());
 
-    // Check if field is required (must exist in JSON)
-    methodBuilder.beginControlFlow("if (!$L.has($S))", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, field.getName())
-        .addStatement("throw new $T($S)", RuntimeException.class,
-            "Required field '" + field.getName() + "' is missing")
-        .endControlFlow();
-
-    // Create access expression for this field
+    final Type fieldType = field.getGenericType();
     final CodeBlock fieldAccess = ParserCommonUtils.createFieldAccessCode(
-        field.getGenericType(),
+        fieldType,
         ParserCommonUtils.BASE_OBJECT_PARAM_NAME,
         CodeBlock.of("$S", field.getName()));
 
-    // Use existing TypeParser infrastructure to generate parsing code with field name as variable name
+    if (ParserCommonUtils.isPrimitiveType(fieldType)) {
+      methodBuilder.beginControlFlow("if (!$L.has($S))", ParserCommonUtils.BASE_OBJECT_PARAM_NAME, field.getName())
+          .addStatement("throw new $T($S)", RuntimeException.class,
+              "Required field '" + field.getName() + "' is missing")
+          .endControlFlow();
+
+      final CodeBlock.Builder parseCode = CodeBlock.builder();
+      final String resultVar = dispatchGenerateParsingCodeInto(
+          parseCode,
+          fieldType,
+          ParserCommonUtils.BASE_OBJECT_PARAM_NAME,
+          parserPackage,
+          fieldAccess,
+          1,
+          fieldType,
+          field.getName());
+      methodBuilder.addCode(parseCode.build());
+      return resultVar;
+    }
+
+    // Non-primitive: pre-declare a nullable outer variable, populate it only when the JSON entry is
+    // present and non-null. The dispatched parser writes into a suffixed inner variable to avoid
+    // colliding with the outer declaration.
+    methodBuilder.addStatement("$T $L = null", TypeName.get(fieldType), field.getName());
+
     final CodeBlock.Builder parseCode = CodeBlock.builder();
-    final String resultVar = dispatchGenerateParsingCodeInto(
+    parseCode.beginControlFlow("if ($L.has($S) && !$L.isNull($S))",
+        ParserCommonUtils.BASE_OBJECT_PARAM_NAME, field.getName(),
+        ParserCommonUtils.BASE_OBJECT_PARAM_NAME, field.getName());
+    final String innerVarName = field.getName() + "Value";
+    final String dispatchedVar = dispatchGenerateParsingCodeInto(
         parseCode,
-        field.getGenericType(),
+        fieldType,
         ParserCommonUtils.BASE_OBJECT_PARAM_NAME,
         parserPackage,
         fieldAccess,
         1,
-        field.getGenericType(),
-        field.getName());
-
+        fieldType,
+        innerVarName);
+    parseCode.addStatement("$L = $L", field.getName(), dispatchedVar);
+    parseCode.endControlFlow();
     methodBuilder.addCode(parseCode.build());
-    return resultVar;
+
+    return field.getName();
   }
 
   private static MethodSpec createConfigParseMethod(final Class<?> targetClass, final String parserPackage) {

--- a/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/MapFieldParser.java
+++ b/gwt-beans-codegen-core/src/main/java/nl/aerius/codegen/generator/parser/MapFieldParser.java
@@ -1,5 +1,6 @@
 package nl.aerius.codegen.generator.parser;
 
+import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Map;
@@ -8,6 +9,7 @@ import com.palantir.javapoet.ClassName;
 import com.palantir.javapoet.CodeBlock;
 
 import nl.aerius.codegen.generator.ParserWriterUtils;
+import nl.aerius.codegen.util.ClassFinder;
 import nl.aerius.codegen.util.Logger;
 
 /**
@@ -15,9 +17,11 @@ import nl.aerius.codegen.util.Logger;
  */
 public class MapFieldParser implements TypeParser {
 
+  private final ClassFinder classFinder;
   private final Logger logger;
 
-  public MapFieldParser(final Logger logger) {
+  public MapFieldParser(final ClassFinder classFinder, final Logger logger) {
+    this.classFinder = classFinder;
     this.logger = logger;
   }
 
@@ -118,8 +122,16 @@ public class MapFieldParser implements TypeParser {
 
     // Introduce intermediate key variable specifically for Enum keys
     if (keyType instanceof Class<?> && ((Class<?>) keyType).isEnum()) {
+      final Class<?> enumType = (Class<?>) keyType;
+      final Method jsonCreatorMethod = ParserCommonUtils.findJsonCreatorMethod(enumType, classFinder, logger);
       final String enumKeyVar = ParserCommonUtils.getVariableNameForLevel(level, "EnumKey");
-      code.addStatement("final $T $L = $T.valueOf($L)", keyType, enumKeyVar, keyType, keyVar);
+      if (jsonCreatorMethod != null) {
+        // Server emits the key via @JsonValue; deserialize via the matching @JsonCreator factory
+        // (Enum.valueOf only accepts the Java constant name, not the JSON form).
+        code.addStatement("final $T $L = $T.$L($L)", keyType, enumKeyVar, keyType, jsonCreatorMethod.getName(), keyVar);
+      } else {
+        code.addStatement("final $T $L = $T.valueOf($L)", keyType, enumKeyVar, keyType, keyVar);
+      }
       code.addStatement("$L.put($L, $L)", mapVar, enumKeyVar, valueVarName); // Use intermediate variable
     } else {
       // Original logic for other key types (String, Integer, etc.)

--- a/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/GeneratedParserRoundTripTest.java
+++ b/gwt-beans-codegen-core/src/test/java/nl/aerius/codegen/test/GeneratedParserRoundTripTest.java
@@ -1,7 +1,17 @@
 package nl.aerius.codegen.test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 import org.junit.jupiter.api.Test;
 
+import nl.aerius.codegen.test.types.TestRecordType;
 import nl.aerius.codegen.test.types.TestRootObjectType;
 
 /**
@@ -43,5 +53,46 @@ class GeneratedParserRoundTripTest extends AbstractRoundTripTest {
     TestRootObjectType original = TestRootObjectType.createNullObject();
 
     assertRoundTrip(original, parserClass);
+  }
+
+  /**
+   * The constructor-based parser must tolerate JSON that omits non-primitive fields entirely
+   * (not just sends them as {@code null}). Jackson's default null-suppressing serialization
+   * produces this shape, so records would otherwise blow up with "Required field is missing"
+   * the moment any optional component is null on the server side.
+   */
+  @Test
+  void shouldHandleOmittedNonPrimitiveFieldsInRecord() throws Exception {
+    prepareParser();
+
+    final Class<?> parserClass = findParserForType(TestRecordType.class);
+    final Method parseMethod = parserClass.getMethod("parse", String.class);
+
+    // Only the primitive component is present; "name" and "tags" are missing keys, not null values.
+    final Object parsed = parseMethod.invoke(null, "{\"value\":42}");
+
+    assertNotNull(parsed, "Parser should construct a record despite missing non-primitive fields");
+    assertEquals(42, parsed.getClass().getMethod("value").invoke(parsed));
+    assertNull(parsed.getClass().getMethod("name").invoke(parsed),
+        "Missing String component should default to null");
+    assertNull(parsed.getClass().getMethod("tags").invoke(parsed),
+        "Missing collection component should default to null");
+  }
+
+  /**
+   * Primitives can't be null, so their absence still indicates a malformed payload - keep throwing.
+   */
+  @Test
+  void shouldThrowOnMissingPrimitiveFieldInRecord() throws Exception {
+    prepareParser();
+
+    final Class<?> parserClass = findParserForType(TestRecordType.class);
+    final Method parseMethod = parserClass.getMethod("parse", String.class);
+
+    final InvocationTargetException ex = assertThrows(InvocationTargetException.class,
+        () -> parseMethod.invoke(null, "{}"));
+    assertTrue(ex.getCause() instanceof RuntimeException);
+    assertTrue(ex.getCause().getMessage().contains("Required field 'value' is missing"),
+        "Expected message about missing primitive 'value', got: " + ex.getCause().getMessage());
   }
 }

--- a/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestConstructorBasedTypeParser.java
+++ b/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestConstructorBasedTypeParser.java
@@ -21,10 +21,11 @@ public class TestConstructorBasedTypeParser {
     }
 
     // Parse name
-    if (!baseObj.has("name")) {
-      throw new RuntimeException("Required field 'name' is missing");
+    String name = null;
+    if (baseObj.has("name") && !baseObj.isNull("name")) {
+      final String nameValue = baseObj.getString("name");
+      name = nameValue;
     }
-    final String name = baseObj.getString("name");
 
     // Parse value
     if (!baseObj.has("value")) {
@@ -33,10 +34,11 @@ public class TestConstructorBasedTypeParser {
     final int value = baseObj.getInteger("value");
 
     // Parse optionalValue
-    if (!baseObj.has("optionalValue")) {
-      throw new RuntimeException("Required field 'optionalValue' is missing");
+    Double optionalValue = null;
+    if (baseObj.has("optionalValue") && !baseObj.isNull("optionalValue")) {
+      final Double optionalValueValue = baseObj.getNumber("optionalValue");
+      optionalValue = optionalValueValue;
     }
-    final Double optionalValue = baseObj.getNumber("optionalValue");
 
     return new TestConstructorBasedType(name, value, optionalValue);
   }

--- a/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestConstructorWithGenericsTypeParser.java
+++ b/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestConstructorWithGenericsTypeParser.java
@@ -29,54 +29,59 @@ public class TestConstructorWithGenericsTypeParser {
     }
 
     // Parse tags
-    if (!baseObj.has("tags")) {
-      throw new RuntimeException("Required field 'tags' is missing");
+    List<String> tags = null;
+    if (baseObj.has("tags") && !baseObj.isNull("tags")) {
+      final JSONArrayHandle tagsValueArray = baseObj.getArray("tags");
+      final List<String> tagsValue = new ArrayList<>();
+      tagsValueArray.forEachString(tagsValue::add);
+      tags = tagsValue;
     }
-    final JSONArrayHandle tagsArray = baseObj.getArray("tags");
-    final List<String> tags = new ArrayList<>();
-    tagsArray.forEachString(tags::add);
 
     // Parse counts
-    if (!baseObj.has("counts")) {
-      throw new RuntimeException("Required field 'counts' is missing");
+    Map<String, Integer> counts = null;
+    if (baseObj.has("counts") && !baseObj.isNull("counts")) {
+      final JSONObjectHandle obj = baseObj.getObject("counts");
+      final Map<String, Integer> countsValue = new LinkedHashMap<>();
+      obj.keySet().forEach(key -> {
+        final Integer level2Value = obj.getInteger(key);
+        countsValue.put(key, level2Value);
+      });
+      counts = countsValue;
     }
-    final JSONObjectHandle obj = baseObj.getObject("counts");
-    final Map<String, Integer> counts = new LinkedHashMap<>();
-    obj.keySet().forEach(key -> {
-      final Integer level2Value = obj.getInteger(key);
-      counts.put(key, level2Value);
-    });
 
     // Parse labels
-    if (!baseObj.has("labels")) {
-      throw new RuntimeException("Required field 'labels' is missing");
+    Set<String> labels = null;
+    if (baseObj.has("labels") && !baseObj.isNull("labels")) {
+      final JSONArrayHandle labelsValueArray = baseObj.getArray("labels");
+      final Set<String> labelsValue = new HashSet<>();
+      labelsValueArray.forEachString(labelsValue::add);
+      labels = labelsValue;
     }
-    final JSONArrayHandle labelsArray = baseObj.getArray("labels");
-    final Set<String> labels = new HashSet<>();
-    labelsArray.forEachString(labels::add);
 
     // Parse sizes
-    if (!baseObj.has("sizes")) {
-      throw new RuntimeException("Required field 'sizes' is missing");
-    }
     int[] sizes = null;
-    final JSONArrayHandle sizesJsonArray = baseObj.getArray("sizes");
-    if (sizesJsonArray != null) {
-      final List<Integer> sizesTempList = new ArrayList<>();
-      sizesJsonArray.forEachInteger(sizesTempList::add);
-      sizes = sizesTempList.stream().mapToInt(i -> i != null ? i.intValue() : 0).toArray();
+    if (baseObj.has("sizes") && !baseObj.isNull("sizes")) {
+      int[] sizesValue = null;
+      final JSONArrayHandle sizesValueJsonArray = baseObj.getArray("sizes");
+      if (sizesValueJsonArray != null) {
+        final List<Integer> sizesValueTempList = new ArrayList<>();
+        sizesValueJsonArray.forEachInteger(sizesValueTempList::add);
+        sizesValue = sizesValueTempList.stream().mapToInt(i -> i != null ? i.intValue() : 0).toArray();
+      }
+      sizes = sizesValue;
     }
 
     // Parse aliases
-    if (!baseObj.has("aliases")) {
-      throw new RuntimeException("Required field 'aliases' is missing");
-    }
     String[] aliases = null;
-    final JSONArrayHandle aliasesJsonArray = baseObj.getArray("aliases");
-    if (aliasesJsonArray != null) {
-      final List<String> aliasesTempList = new ArrayList<>();
-      aliasesJsonArray.forEachString(aliasesTempList::add);
-      aliases = aliasesTempList.toArray(new String[0]);
+    if (baseObj.has("aliases") && !baseObj.isNull("aliases")) {
+      String[] aliasesValue = null;
+      final JSONArrayHandle aliasesValueJsonArray = baseObj.getArray("aliases");
+      if (aliasesValueJsonArray != null) {
+        final List<String> aliasesValueTempList = new ArrayList<>();
+        aliasesValueJsonArray.forEachString(aliasesValueTempList::add);
+        aliasesValue = aliasesValueTempList.toArray(new String[0]);
+      }
+      aliases = aliasesValue;
     }
 
     return new TestConstructorWithGenericsType(tags, counts, labels, sizes, aliases);

--- a/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestConstructorWithIgnoredFieldTypeParser.java
+++ b/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestConstructorWithIgnoredFieldTypeParser.java
@@ -21,10 +21,11 @@ public class TestConstructorWithIgnoredFieldTypeParser {
     }
 
     // Parse name
-    if (!baseObj.has("name")) {
-      throw new RuntimeException("Required field 'name' is missing");
+    String name = null;
+    if (baseObj.has("name") && !baseObj.isNull("name")) {
+      final String nameValue = baseObj.getString("name");
+      name = nameValue;
     }
-    final String name = baseObj.getString("name");
 
     return new TestConstructorWithIgnoredFieldType(name);
   }

--- a/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestRecordTypeParser.java
+++ b/gwt-beans-codegen-core/src/test/resources/parsers/expected/TestRecordTypeParser.java
@@ -25,10 +25,11 @@ public class TestRecordTypeParser {
     }
 
     // Parse name
-    if (!baseObj.has("name")) {
-      throw new RuntimeException("Required field 'name' is missing");
+    String name = null;
+    if (baseObj.has("name") && !baseObj.isNull("name")) {
+      final String nameValue = baseObj.getString("name");
+      name = nameValue;
     }
-    final String name = baseObj.getString("name");
 
     // Parse value
     if (!baseObj.has("value")) {
@@ -37,12 +38,13 @@ public class TestRecordTypeParser {
     final int value = baseObj.getInteger("value");
 
     // Parse tags
-    if (!baseObj.has("tags")) {
-      throw new RuntimeException("Required field 'tags' is missing");
+    List<String> tags = null;
+    if (baseObj.has("tags") && !baseObj.isNull("tags")) {
+      final JSONArrayHandle tagsValueArray = baseObj.getArray("tags");
+      final List<String> tagsValue = new ArrayList<>();
+      tagsValueArray.forEachString(tagsValue::add);
+      tags = tagsValue;
     }
-    final JSONArrayHandle tagsArray = baseObj.getArray("tags");
-    final List<String> tags = new ArrayList<>();
-    tagsArray.forEachString(tags::add);
 
     return new TestRecordType(name, value, tags);
   }


### PR DESCRIPTION
Constructor-based parsing now mirrors the setter path: non-primitive fields default to null when their JSON key is missing instead of throwing, so records like ResultsKey no longer blow up when Jackson omits null components on the server side.

Also, for enums which serialize using `@JsonValue`, use the `@JsonCreator` to parse it