### PR TITLE
Bump jackson-databind to 2.18.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jackson.version>2.16.1</jackson.version>
+    <jackson.version>2.18.8</jackson.version>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
   </properties>


### PR DESCRIPTION
Bumps jackson-databind 2.16.1 -> 2.18.8 to clear the Dependabot alert (CVE-2026-54512/54513/54514).

Only used in the test-scoped JSON stub module, and only for JsonNode tree parsing, so there was no actual exposure; this just keeps the dependency current and silences the alert.