### PR TITLE
Only run our workflows on the aerius repository

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   job:
+    if: github.repository == 'aerius/gwt-beans-maven-plugin'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/on-code-push.yml
+++ b/.github/workflows/on-code-push.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   job:
+    if: github.repository == 'aerius/gwt-beans-maven-plugin'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/on-new-tag.yml
+++ b/.github/workflows/on-new-tag.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   job:
+    if: github.repository == 'aerius/gwt-beans-maven-plugin'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/on-pull_request-opened-synchronize-reopened.yml
+++ b/.github/workflows/on-pull_request-opened-synchronize-reopened.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   job:
+    if: github.repository == 'aerius/gwt-beans-maven-plugin'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This is part of a round of mass gha workflow refinements, where up to 2 rules are applied:

- Rule 1: a workflow only runs when the repository is aerius/gwt-beans-maven-plugin
- Rule 2: a push workflow only triggers on main and the `*_fixes` branches

For this repo:

Rule 1 is applied to `create-release.yml`, `on-code-push.yml`, `on-new-tag.yml` and `on-pull_request-opened-synchronize-reopened.yml`
Rule 2 has already been applied

---
<details>
<summary>LLM-generated technical summary</summary>

A job-level `if: github.repository == 'aerius/gwt-beans-maven-plugin'` stops the job in any fork while leaving behavior in the canonical repo unchanged. It is deliberately at job level rather than inside the shared composite actions in `aerius/github-actions`: a composite action has no `on:` block and can only gate individual steps, so a central version would still spin up the runner and run a full build before declining to publish.

On a `pull_request` event `github.repository` is the base repository, so the guard is false only when the PR's base is itself a fork. A PR from a fork into the canonical repo is unaffected.

Note for anyone rehearsing a release in their own fork: a guarded job skips silently rather than failing, so the `if:` line has to come out locally first.
</details>
